### PR TITLE
fix(swim): correct column name mismatches across 9 VATSWIM reference endpoints

### DIFF
--- a/api/swim/v1/reference/aircraft.php
+++ b/api/swim/v1/reference/aircraft.php
@@ -154,7 +154,7 @@ function handleTypeList($families, $format, $cache_params, $format_options) {
     $params = [];
 
     if ($search) {
-        $where[] = "(ICAO_Code LIKE ? OR Manufacturer LIKE ? OR Model LIKE ?)";
+        $where[] = "(ICAO_Code LIKE ? OR Manufacturer LIKE ? OR Model_FAA LIKE ?)";
         $like = '%' . $search . '%';
         $params = array_merge($params, [$like, $like, $like]);
     }
@@ -163,15 +163,15 @@ function handleTypeList($families, $format, $cache_params, $format_options) {
         $params[] = '%' . $manufacturer . '%';
     }
     if ($weight_class) {
-        $where[] = "WeightClass = ?";
+        $where[] = "FAA_Weight = ?";
         $params[] = strtoupper($weight_class);
     }
     if ($wake_category) {
-        $where[] = "WTC = ?";
+        $where[] = "ICAO_WTC = ?";
         $params[] = strtoupper($wake_category);
     }
     if ($engine_type) {
-        $where[] = "EngineType LIKE ?";
+        $where[] = "Physical_Class_Engine LIKE ?";
         $params[] = '%' . $engine_type . '%';
     }
 
@@ -311,11 +311,11 @@ function handlePerformance($icao, $format, $cache_params, $format_options) {
 function formatTypeRow($row) {
     return [
         'icao_code' => $row['ICAO_Code'] ?? $row['icao_code'] ?? null,
-        'name' => $row['TypeName'] ?? $row['Model'] ?? null,
+        'name' => $row['Model_FAA'] ?? $row['Model_BADA'] ?? null,
         'manufacturer' => $row['Manufacturer'] ?? null,
-        'weight_class' => $row['WeightClass'] ?? null,
-        'wake_category' => $row['WTC'] ?? null,
-        'engine_type' => $row['EngineType'] ?? null,
-        'engine_count' => isset($row['EngineCount']) ? (int)$row['EngineCount'] : null,
+        'weight_class' => $row['FAA_Weight'] ?? null,
+        'wake_category' => $row['ICAO_WTC'] ?? null,
+        'engine_type' => $row['Physical_Class_Engine'] ?? null,
+        'engine_count' => isset($row['Num_Engines']) ? (int)$row['Num_Engines'] : null,
     ];
 }

--- a/api/swim/v1/reference/airlines.php
+++ b/api/swim/v1/reference/airlines.php
@@ -76,9 +76,9 @@ if ($airline_code !== null) {
 
 function handleSingleAirline($conn, $code, $format, $cache_params, $format_options) {
     // Try ICAO first, then IATA
-    $sql = "SELECT icao_code, iata_code, name, callsign, country
+    $sql = "SELECT icao, iata, name, callsign, country
             FROM dbo.airlines
-            WHERE icao_code = ? OR iata_code = ?";
+            WHERE icao = ? OR iata = ?";
     $stmt = sqlsrv_query($conn, $sql, [$code, $code]);
     if ($stmt === false) {
         SwimResponse::error('Database query failed', 500, 'DB_ERROR');
@@ -100,7 +100,7 @@ function handleAirlineList($conn, $search, $country, $page, $per_page, $format, 
     $params = [];
 
     if ($search) {
-        $where[] = "(name LIKE ? OR callsign LIKE ? OR icao_code LIKE ? OR iata_code LIKE ?)";
+        $where[] = "(name LIKE ? OR callsign LIKE ? OR icao LIKE ? OR iata LIKE ?)";
         $like = '%' . $search . '%';
         $params = array_merge($params, [$like, $like, $like, $like]);
     }
@@ -124,10 +124,10 @@ function handleAirlineList($conn, $search, $country, $page, $per_page, $format, 
 
     // Fetch page
     $offset = ($page - 1) * $per_page;
-    $sql = "SELECT icao_code, iata_code, name, callsign, country
+    $sql = "SELECT icao, iata, name, callsign, country
             FROM dbo.airlines
             $where_sql
-            ORDER BY icao_code
+            ORDER BY icao
             OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
     $params[] = $offset;
     $params[] = $per_page;
@@ -154,8 +154,8 @@ function handleAirlineList($conn, $search, $country, $page, $per_page, $format, 
 
 function formatAirlineRow($row) {
     return [
-        'icao_code' => $row['icao_code'] ?? null,
-        'iata_code' => $row['iata_code'] ?? null,
+        'icao_code' => $row['icao'] ?? null,
+        'iata_code' => $row['iata'] ?? null,
         'name' => $row['name'] ?? null,
         'callsign' => $row['callsign'] ?? null,
         'country' => $row['country'] ?? null,

--- a/api/swim/v1/reference/airports.php
+++ b/api/swim/v1/reference/airports.php
@@ -84,10 +84,10 @@ function handleLookup($format, $cache_params, $format_options) {
     }
 
     if ($faa) {
-        $stmt = $conn->prepare("SELECT icao_code, faa_lid, name, city, state_code, country_code FROM airports WHERE faa_lid = :faa LIMIT 5");
+        $stmt = $conn->prepare("SELECT icao_id, iata_id, airport_name, country_code, region_code FROM airports WHERE iata_id = :faa LIMIT 5");
         $stmt->execute([':faa' => strtoupper($faa)]);
     } else {
-        $stmt = $conn->prepare("SELECT icao_code, faa_lid, name, city, state_code, country_code FROM airports WHERE icao_code = :icao LIMIT 5");
+        $stmt = $conn->prepare("SELECT icao_id, iata_id, airport_name, country_code, region_code FROM airports WHERE icao_id = :icao LIMIT 5");
         $stmt->execute([':icao' => strtoupper($icao)]);
     }
 
@@ -109,11 +109,11 @@ function handleAirportProfile($code, $include_geometry, $format, $cache_params, 
     }
 
     $geom_col = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
-    $sql = "SELECT icao_code, faa_lid, name, city, state_code, country_code,
-                   latitude, longitude, elevation_ft, mag_var, is_towered, airport_class
+    $sql = "SELECT icao_id, iata_id, airport_name, country_code, region_code,
+                   lat, lon, elevation_ft, airport_type, parent_artcc, parent_tracon
                    $geom_col
             FROM airports
-            WHERE " . (strlen($code) === 3 ? "faa_lid = :code" : "icao_code = :code") . "
+            WHERE " . (strlen($code) === 3 ? "iata_id = :code" : "icao_id = :code") . "
             LIMIT 1";
 
     $stmt = $conn->prepare($sql);
@@ -122,11 +122,11 @@ function handleAirportProfile($code, $include_geometry, $format, $cache_params, 
 
     if (!$row) {
         // Try the other field
-        $alt_sql = "SELECT icao_code, faa_lid, name, city, state_code, country_code,
-                           latitude, longitude, elevation_ft, mag_var, is_towered, airport_class
+        $alt_sql = "SELECT icao_id, iata_id, airport_name, country_code, region_code,
+                           lat, lon, elevation_ft, airport_type, parent_artcc, parent_tracon
                            $geom_col
                     FROM airports
-                    WHERE " . (strlen($code) === 3 ? "icao_code = :code" : "faa_lid = :code") . "
+                    WHERE " . (strlen($code) === 3 ? "icao_id = :code" : "iata_id = :code") . "
                     LIMIT 1";
         $stmt2 = $conn->prepare($alt_sql);
         $stmt2->execute([':code' => $code]);
@@ -151,7 +151,7 @@ function handleFacilities($code, $format, $cache_params, $format_options) {
     }
 
     $conn = get_conn_gis();
-    $stmt = $conn->prepare("SELECT latitude, longitude FROM airports WHERE icao_code = :code OR faa_lid = :code LIMIT 1");
+    $stmt = $conn->prepare("SELECT lat, lon FROM airports WHERE icao_id = :code OR iata_id = :code LIMIT 1");
     $stmt->execute([':code' => $code]);
     $apt = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -159,7 +159,7 @@ function handleFacilities($code, $format, $cache_params, $format_options) {
         SwimResponse::error("Airport not found: $code", 404, 'NOT_FOUND');
     }
 
-    $boundaries = $gis->getBoundariesAtPoint((float)$apt['latitude'], (float)$apt['longitude']);
+    $boundaries = $gis->getBoundariesAtPoint((float)$apt['lat'], (float)$apt['lon']);
 
     SwimResponse::formatted([
         'airport' => $code,
@@ -268,10 +268,10 @@ function handleSearch($include_geometry, $format, $cache_params, $format_options
     $geom_col = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
     $where = [];
     $params = [];
-    $order_by = "name";
+    $order_by = "airport_name";
 
     if ($q) {
-        $where[] = "(icao_code ILIKE :q OR faa_lid ILIKE :q OR name ILIKE :qw OR city ILIKE :qw)";
+        $where[] = "(icao_id ILIKE :q OR iata_id ILIKE :q OR airport_name ILIKE :qw)";
         $params[':q'] = $q . '%';
         $params[':qw'] = '%' . $q . '%';
     }
@@ -297,7 +297,7 @@ function handleSearch($include_geometry, $format, $cache_params, $format_options
     }
 
     if ($airport_class) {
-        $where[] = "airport_class = :class";
+        $where[] = "airport_type = :class";
         $params[':class'] = $airport_class;
     }
 
@@ -311,8 +311,8 @@ function handleSearch($include_geometry, $format, $cache_params, $format_options
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
     // Fetch
-    $sql = "SELECT icao_code, faa_lid, name, city, state_code, country_code,
-                   latitude, longitude, elevation_ft, airport_class $geom_col
+    $sql = "SELECT icao_id, iata_id, airport_name, country_code, region_code,
+                   lat, lon, elevation_ft, airport_type $geom_col
             FROM airports $where_sql
             ORDER BY $order_by
             LIMIT :limit OFFSET :offset";

--- a/api/swim/v1/reference/airspace.php
+++ b/api/swim/v1/reference/airspace.php
@@ -222,7 +222,7 @@ function handleFirs($conn, $include_geometry, $format, $cache_params, $format_op
     $count_stmt->execute($params);
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
-    $sql = "SELECT artcc_code, artcc_name, hierarchy_type, is_oceanic $geom
+    $sql = "SELECT artcc_code, fir_name, hierarchy_type, is_oceanic $geom
             FROM artcc_boundaries $where_sql
             ORDER BY artcc_code LIMIT :limit OFFSET :offset";
     $params[':limit'] = $per_page;
@@ -261,7 +261,7 @@ function handleSectors($conn, $include_geometry, $format, $cache_params, $format
     $count_stmt->execute($params);
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
-    $sql = "SELECT sector_code, sector_name, parent_artcc, sector_type, floor_fl, ceiling_fl $geom
+    $sql = "SELECT sector_code, sector_name, parent_artcc, sector_type, floor_altitude, ceiling_altitude $geom
             FROM sector_boundaries $where_sql
             ORDER BY parent_artcc, sector_code LIMIT :limit OFFSET :offset";
     $params[':limit'] = $per_page;
@@ -281,9 +281,9 @@ function handleSectors($conn, $include_geometry, $format, $cache_params, $format
 
 function getBoundaryTable($type) {
     $tables = [
-        'artcc' => ['table' => 'artcc_boundaries', 'code_col' => 'artcc_code', 'list_cols' => 'artcc_code, artcc_name, hierarchy_type, is_oceanic'],
+        'artcc' => ['table' => 'artcc_boundaries', 'code_col' => 'artcc_code', 'list_cols' => 'artcc_code, fir_name, hierarchy_type, is_oceanic'],
         'tracon' => ['table' => 'tracon_boundaries', 'code_col' => 'tracon_code', 'list_cols' => 'tracon_code, tracon_name, parent_artcc'],
-        'sector' => ['table' => 'sector_boundaries', 'code_col' => 'sector_code', 'list_cols' => 'sector_code, sector_name, parent_artcc, sector_type, floor_fl, ceiling_fl'],
+        'sector' => ['table' => 'sector_boundaries', 'code_col' => 'sector_code', 'list_cols' => 'sector_code, sector_name, parent_artcc, sector_type, floor_altitude, ceiling_altitude'],
     ];
     return $tables[strtolower($type)] ?? null;
 }

--- a/api/swim/v1/reference/facilities.php
+++ b/api/swim/v1/reference/facilities.php
@@ -90,7 +90,7 @@ function handleCenterList($include_geometry, $format, $cache_params, $format_opt
     if (!$conn) SwimResponse::error('GIS unavailable', 503, 'SERVICE_UNAVAILABLE');
 
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
-    $sql = "SELECT artcc_code, artcc_name, hierarchy_type, is_oceanic $geom
+    $sql = "SELECT artcc_code, fir_name, hierarchy_type, is_oceanic $geom
             FROM artcc_boundaries ORDER BY artcc_code";
     $stmt = $conn->query($sql);
     $centers = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -110,7 +110,7 @@ function handleCenterDetail($code, $include_geometry, $format, $cache_params, $f
     if (!$conn) SwimResponse::error('GIS unavailable', 503, 'SERVICE_UNAVAILABLE');
 
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
-    $sql = "SELECT artcc_code, artcc_name, hierarchy_type, is_oceanic $geom
+    $sql = "SELECT artcc_code, fir_name, hierarchy_type, is_oceanic $geom
             FROM artcc_boundaries WHERE artcc_code = :code LIMIT 1";
     $stmt = $conn->prepare($sql);
     $stmt->execute([':code' => $code]);
@@ -164,7 +164,7 @@ function handleCenterSectors($code, $format, $cache_params, $format_options) {
     $params = [':code' => $code];
     if ($strata) { $where[] = "sector_type = :strata"; $params[':strata'] = strtoupper($strata); }
 
-    $sql = "SELECT sector_code, sector_name, sector_type, floor_fl, ceiling_fl
+    $sql = "SELECT sector_code, sector_name, sector_type, floor_altitude, ceiling_altitude
             FROM sector_boundaries WHERE " . implode(' AND ', $where) . "
             ORDER BY sector_type, sector_code";
     $stmt = $conn->prepare($sql);
@@ -217,11 +217,11 @@ function handleTraconDetail($code, $include_geometry, $format, $cache_params, $f
     if (isset($tracon['geometry'])) $tracon['geometry'] = json_decode($tracon['geometry'], true);
 
     // Get airports within this TRACON via spatial containment
-    $apt_sql = "SELECT a.icao_code, a.faa_lid, a.name
+    $apt_sql = "SELECT a.icao_id, a.iata_id, a.airport_name
                 FROM airports a, tracon_boundaries t
                 WHERE t.tracon_code = :code
                 AND ST_Contains(t.geom, a.geom)
-                ORDER BY a.icao_code";
+                ORDER BY a.icao_id";
     $apt_stmt = $conn->prepare($apt_sql);
     $apt_stmt->execute([':code' => $code]);
     $airports = $apt_stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/api/swim/v1/reference/hierarchy.php
+++ b/api/swim/v1/reference/hierarchy.php
@@ -149,7 +149,7 @@ function handleCenterNode($data, $code, $include_geometry, $format, $cache_param
     if (!$conn) SwimResponse::error('GIS unavailable', 503, 'SERVICE_UNAVAILABLE');
 
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
-    $stmt = $conn->prepare("SELECT artcc_code, artcc_name, hierarchy_type $geom FROM artcc_boundaries WHERE artcc_code = :code LIMIT 1");
+    $stmt = $conn->prepare("SELECT artcc_code, fir_name, hierarchy_type $geom FROM artcc_boundaries WHERE artcc_code = :code LIMIT 1");
     $stmt->execute([':code' => $code]);
     $center = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -175,7 +175,7 @@ function handleCenterNode($data, $code, $include_geometry, $format, $cache_param
     SwimResponse::formatted([
         'node' => [
             'code' => $center['artcc_code'],
-            'name' => $center['artcc_name'],
+            'name' => $center['fir_name'],
             'type' => 'center',
             'geometry' => $center['geometry'] ?? null,
             'detail_url' => "/api/swim/v1/reference/facilities/centers/$code",
@@ -204,8 +204,8 @@ function handleTraconNode($data, $code, $include_geometry, $format, $cache_param
     if (isset($tracon['geometry'])) $tracon['geometry'] = json_decode($tracon['geometry'], true);
 
     // Get airports within TRACON
-    $apt_sql = "SELECT a.icao_code, a.faa_lid, a.name FROM airports a, tracon_boundaries t
-                WHERE t.tracon_code = :code AND ST_Contains(t.geom, a.geom) ORDER BY a.icao_code";
+    $apt_sql = "SELECT a.icao_id, a.iata_id, a.airport_name FROM airports a, tracon_boundaries t
+                WHERE t.tracon_code = :code AND ST_Contains(t.geom, a.geom) ORDER BY a.icao_id";
     $apt_stmt = $conn->prepare($apt_sql);
     $apt_stmt->execute([':code' => $code]);
     $airports = $apt_stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -224,7 +224,7 @@ function handleTraconNode($data, $code, $include_geometry, $format, $cache_param
         'breadcrumb' => $breadcrumb,
         'children' => [
             'airports' => array_map(fn($a) => [
-                'code' => $a['icao_code'], 'faa_lid' => $a['faa_lid'], 'name' => $a['name'], 'type' => 'airport'
+                'code' => $a['icao_id'], 'iata_id' => $a['iata_id'], 'name' => $a['airport_name'], 'type' => 'airport'
             ], $airports),
         ],
         'summary' => ['total_airports' => count($airports)],
@@ -263,7 +263,7 @@ function handleHierarchySearch($data, $format, $cache_params, $format_options) {
     $conn = get_conn_gis();
     if ($conn) {
         if (!$type_filter || $type_filter === 'center') {
-            $stmt = $conn->prepare("SELECT artcc_code AS code, artcc_name AS name FROM artcc_boundaries WHERE artcc_code ILIKE :q OR artcc_name ILIKE :qw LIMIT 20");
+            $stmt = $conn->prepare("SELECT artcc_code AS code, fir_name AS name FROM artcc_boundaries WHERE artcc_code ILIKE :q OR fir_name ILIKE :qw LIMIT 20");
             $stmt->execute([':q' => $q_upper . '%', ':qw' => '%' . $q . '%']);
             foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) { $results[] = array_merge($r, ['type' => 'center']); }
         }
@@ -273,7 +273,7 @@ function handleHierarchySearch($data, $format, $cache_params, $format_options) {
             foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) { $results[] = array_merge($r, ['type' => 'tracon']); }
         }
         if (!$type_filter || $type_filter === 'airport') {
-            $stmt = $conn->prepare("SELECT icao_code AS code, name FROM airports WHERE icao_code ILIKE :q OR faa_lid ILIKE :q OR name ILIKE :qw OR city ILIKE :qw LIMIT 20");
+            $stmt = $conn->prepare("SELECT icao_id AS code, airport_name AS name FROM airports WHERE icao_id ILIKE :q OR iata_id ILIKE :q OR airport_name ILIKE :qw LIMIT 20");
             $stmt->execute([':q' => $q_upper . '%', ':qw' => '%' . $q . '%']);
             foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) { $results[] = array_merge($r, ['type' => 'airport']); }
         }
@@ -297,10 +297,10 @@ function handleChildren($data, $type, $code, $format, $cache_params, $format_opt
         if (!$conn) SwimResponse::error('GIS unavailable', 503, 'SERVICE_UNAVAILABLE');
 
         $offset = ($page - 1) * $per_page;
-        $sql = "SELECT a.icao_code, a.faa_lid, a.name, a.city
+        $sql = "SELECT a.icao_id, a.iata_id, a.airport_name
                 FROM airports a, artcc_boundaries b
                 WHERE b.artcc_code = :code AND ST_Contains(b.geom, a.geom)
-                ORDER BY a.icao_code LIMIT :limit OFFSET :offset";
+                ORDER BY a.icao_id LIMIT :limit OFFSET :offset";
         $stmt = $conn->prepare($sql);
         $stmt->execute([':code' => $code, ':limit' => $per_page, ':offset' => $offset]);
         $airports = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/api/swim/v1/reference/navigation.php
+++ b/api/swim/v1/reference/navigation.php
@@ -96,11 +96,11 @@ switch ($sub) {
 
 function handleFixDetail($conn, $name, $include_geometry, $format, $cache_params, $format_options) {
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
-    $sql = "SELECT fix_name, latitude, longitude, fix_type, artcc_code, country_code,
-                   is_superseded, airac_cycle $geom
+    $sql = "SELECT fix_name, lat, lon, fix_type, artcc_id,
+                   is_superseded $geom
             FROM nav_fixes
             WHERE fix_name = :name AND (is_superseded = false OR is_superseded IS NULL)
-            ORDER BY country_code";
+            ORDER BY fix_name";
     $stmt = $conn->prepare($sql);
     $stmt->execute([':name' => $name]);
     $fixes = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -111,8 +111,9 @@ function handleFixDetail($conn, $name, $include_geometry, $format, $cache_params
 
     foreach ($fixes as &$f) {
         if (isset($f['geometry'])) $f['geometry'] = json_decode($f['geometry'], true);
-        $f['latitude'] = (float)$f['latitude'];
-        $f['longitude'] = (float)$f['longitude'];
+        $f['latitude'] = (float)$f['lat'];
+        $f['longitude'] = (float)$f['lon'];
+        unset($f['lat'], $f['lon']);
     }
 
     SwimResponse::formatted([
@@ -150,12 +151,8 @@ function handleFixList($conn, $include_geometry, $format, $cache_params, $format
         $params[':type'] = strtoupper($type);
     }
     if ($artcc) {
-        $where[] = "artcc_code = :artcc";
+        $where[] = "artcc_id = :artcc";
         $params[':artcc'] = strtoupper($artcc);
-    }
-    if ($country) {
-        $where[] = "country_code = :country";
-        $params[':country'] = strtoupper($country);
     }
 
     $order_by = "fix_name";
@@ -182,7 +179,7 @@ function handleFixList($conn, $include_geometry, $format, $cache_params, $format
     $count_stmt->execute($params);
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
-    $sql = "SELECT fix_name, latitude, longitude, fix_type, artcc_code, country_code $geom
+    $sql = "SELECT fix_name, lat, lon, fix_type, artcc_id $geom
             FROM nav_fixes $where_sql ORDER BY $order_by LIMIT :limit OFFSET :offset";
     $params[':limit'] = $per_page;
     $params[':offset'] = $offset;
@@ -193,8 +190,9 @@ function handleFixList($conn, $include_geometry, $format, $cache_params, $format
 
     foreach ($fixes as &$f) {
         if (isset($f['geometry'])) $f['geometry'] = json_decode($f['geometry'], true);
-        $f['latitude'] = (float)$f['latitude'];
-        $f['longitude'] = (float)$f['longitude'];
+        $f['latitude'] = (float)$f['lat'];
+        $f['longitude'] = (float)$f['lon'];
+        unset($f['lat'], $f['lon']);
     }
 
     $data = ['fixes' => $fixes, 'count' => count($fixes), 'total' => $total];
@@ -206,7 +204,7 @@ function handleFixList($conn, $include_geometry, $format, $cache_params, $format
 function handleAirwayDetail($conn, $name, $include_geometry, $format, $cache_params, $format_options) {
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
 
-    $sql = "SELECT sequence_num, fix_from, fix_to, course, distance_nm, min_altitude_ft $geom
+    $sql = "SELECT sequence_num, from_fix, to_fix, distance_nm $geom
             FROM airway_segments
             WHERE airway_name = :name
             ORDER BY sequence_num";
@@ -306,7 +304,7 @@ function handleAirwayList($conn, $format, $cache_params, $format_options) {
     $count_stmt->execute($params);
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
-    $sql = "SELECT airway_name, airway_type, airac_cycle
+    $sql = "SELECT airway_name, airway_type, source
             FROM airways $where_sql
             ORDER BY airway_name
             LIMIT :limit OFFSET :offset";
@@ -326,8 +324,8 @@ function handleAirwayList($conn, $format, $cache_params, $format_options) {
 function handleProcedureDetail($conn, $computer_code, $include_geometry, $format, $cache_params, $format_options) {
     $geom = $include_geometry ? ", ST_AsGeoJSON(geom, 5) AS geometry" : "";
     $sql = "SELECT computer_code, procedure_name, procedure_type, airport_icao,
-                   transition_name, transition_type, route_string, waypoints,
-                   source, airac_cycle, is_superseded $geom
+                   transition_name, transition_type, full_route,
+                   source, is_superseded $geom
             FROM nav_procedures
             WHERE computer_code = :code
             LIMIT 1";
@@ -340,9 +338,6 @@ function handleProcedureDetail($conn, $computer_code, $include_geometry, $format
     }
 
     if (isset($row['geometry'])) $row['geometry'] = json_decode($row['geometry'], true);
-    if (isset($row['waypoints']) && is_string($row['waypoints'])) {
-        $row['waypoints'] = json_decode($row['waypoints'], true);
-    }
 
     SwimResponse::formatted(['procedure' => $row], $format, 'reference_nav', $cache_params, $format_options);
 }
@@ -384,7 +379,7 @@ function handleProcedureList($conn, $format, $cache_params, $format_options) {
     $total = (int)($count_stmt->fetch(PDO::FETCH_ASSOC)['total'] ?? 0);
 
     $sql = "SELECT computer_code, procedure_name, procedure_type, airport_icao,
-                   transition_name, transition_type, source, airac_cycle
+                   transition_name, transition_type, source
             FROM nav_procedures $where_sql
             ORDER BY airport_icao, procedure_type, procedure_name
             LIMIT :limit OFFSET :offset";

--- a/api/swim/v1/reference/routes.php
+++ b/api/swim/v1/reference/routes.php
@@ -10,6 +10,9 @@
  *   GET /reference/routes/statistics?origin=KJFK&dest=KLAX  - Aggregate city-pair stats
  */
 
+// Load MySQL BEFORE SWIM auth (auth.php sets PERTI_SWIM_ONLY which skips MySQL)
+require_once __DIR__ . '/../../../../load/config.php';
+require_once __DIR__ . '/../../../../load/connect.php';
 require_once __DIR__ . '/../auth.php';
 
 $auth = swim_init_auth(true, false);

--- a/api/swim/v1/reference/utilities.php
+++ b/api/swim/v1/reference/utilities.php
@@ -61,13 +61,13 @@ function resolvePoint($param_name) {
     $code = strtoupper(trim($val));
 
     // Try airports first
-    $stmt = $conn->prepare("SELECT latitude AS lat, longitude AS lon FROM airports WHERE icao_code = :code OR faa_lid = :code LIMIT 1");
+    $stmt = $conn->prepare("SELECT lat, lon FROM airports WHERE icao_id = :code OR iata_id = :code LIMIT 1");
     $stmt->execute([':code' => $code]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($row) return ['lat' => (float)$row['lat'], 'lon' => (float)$row['lon'], 'label' => $code];
 
     // Try fixes
-    $stmt2 = $conn->prepare("SELECT latitude AS lat, longitude AS lon FROM nav_fixes WHERE fix_name = :code AND (is_superseded = false OR is_superseded IS NULL) LIMIT 1");
+    $stmt2 = $conn->prepare("SELECT lat, lon FROM nav_fixes WHERE fix_name = :code AND (is_superseded = false OR is_superseded IS NULL) LIMIT 1");
     $stmt2->execute([':code' => $code]);
     $row2 = $stmt2->fetch(PDO::FETCH_ASSOC);
     if ($row2) return ['lat' => (float)$row2['lat'], 'lon' => (float)$row2['lon'], 'label' => $code];

--- a/database/migrations/vnas/001_vnas_reference_schema.sql
+++ b/database/migrations/vnas/001_vnas_reference_schema.sql
@@ -1,0 +1,224 @@
+-- ============================================================================
+-- Migration 001: vNAS Reference Data Schema
+-- Creates tables for facility hierarchy, positions, STARS TCPs/areas,
+-- beacon banks, transceivers, video map index, airport groups, common URLs,
+-- and sync metadata imported from CRC local ARTCC JSON files.
+--
+-- Source: 24 ARTCC JSON files at %LOCALAPPDATA%/CRC/ARTCCs/*.json
+-- Design: docs/plans/2026-04-07-vnas-reference-sync-design.md
+-- ============================================================================
+
+-- 1. vnas_facilities (782 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_facilities')
+BEGIN
+    CREATE TABLE dbo.vnas_facilities (
+        facility_id               NVARCHAR(8)   NOT NULL PRIMARY KEY,
+        facility_name             NVARCHAR(100) NOT NULL,
+        facility_type             NVARCHAR(16)  NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        parent_facility_id        NVARCHAR(8)   NULL,
+        hierarchy_depth           SMALLINT      NOT NULL DEFAULT 0,
+        neighboring_facility_ids  NVARCHAR(MAX) NULL,
+        non_nas_facility_ids      NVARCHAR(MAX) NULL,
+        has_eram                  BIT NOT NULL DEFAULT 0,
+        has_stars                 BIT NOT NULL DEFAULT 0,
+        has_flight_strips         BIT NOT NULL DEFAULT 0,
+        has_tower_cab             BIT NOT NULL DEFAULT 0,
+        has_asdex                 BIT NOT NULL DEFAULT 0,
+        has_tdls                  BIT NOT NULL DEFAULT 0,
+        eram_config_json          NVARCHAR(MAX) NULL,
+        stars_config_json         NVARCHAR(MAX) NULL,
+        flight_strips_json        NVARCHAR(MAX) NULL,
+        tower_cab_json            NVARCHAR(MAX) NULL,
+        asdex_config_json         NVARCHAR(MAX) NULL,
+        tdls_config_json          NVARCHAR(MAX) NULL,
+        visibility_centers_json   NVARCHAR(MAX) NULL,
+        aliases_updated_at        DATETIME2     NULL,
+        source_artcc              NVARCHAR(4)   NOT NULL,
+        source_updated_at         DATETIME2     NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_facilities_parent ON dbo.vnas_facilities (parent_artcc, facility_type);
+    CREATE INDEX IX_vnas_facilities_type ON dbo.vnas_facilities (facility_type);
+    PRINT 'Created table: dbo.vnas_facilities';
+END
+GO
+
+-- 2. vnas_positions (3,990 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_positions')
+BEGIN
+    CREATE TABLE dbo.vnas_positions (
+        position_ulid             NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        facility_id               NVARCHAR(8)   NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        position_name             NVARCHAR(50)  NOT NULL,
+        callsign                  NVARCHAR(20)  NOT NULL,
+        radio_name                NVARCHAR(50)  NULL,
+        frequency_hz              INT           NOT NULL,
+        starred                   BIT           NOT NULL DEFAULT 0,
+        eram_sector_id            NVARCHAR(8)   NULL,
+        stars_area_id             NVARCHAR(32)  NULL,
+        stars_tcp_id              NVARCHAR(32)  NULL,
+        stars_color_set           NVARCHAR(8)   NULL,
+        transceiver_ids_json      NVARCHAR(MAX) NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_positions_facility ON dbo.vnas_positions (facility_id);
+    CREATE INDEX IX_vnas_positions_artcc ON dbo.vnas_positions (parent_artcc);
+    CREATE INDEX IX_vnas_positions_callsign ON dbo.vnas_positions (callsign);
+    PRINT 'Created table: dbo.vnas_positions';
+END
+GO
+
+-- 3. vnas_stars_tcps (1,949 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_stars_tcps')
+BEGIN
+    CREATE TABLE dbo.vnas_stars_tcps (
+        tcp_id                    NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        facility_id               NVARCHAR(8)   NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        subset                    SMALLINT      NOT NULL,
+        sector_id                 NVARCHAR(4)   NOT NULL,
+        parent_tcp_id             NVARCHAR(32)  NULL,
+        terminal_sector           BIT           NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_stars_tcps_facility ON dbo.vnas_stars_tcps (facility_id, sector_id);
+    CREATE INDEX IX_vnas_stars_tcps_parent ON dbo.vnas_stars_tcps (parent_tcp_id);
+    PRINT 'Created table: dbo.vnas_stars_tcps';
+END
+GO
+
+-- 4. vnas_stars_areas (647 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_stars_areas')
+BEGIN
+    CREATE TABLE dbo.vnas_stars_areas (
+        area_id                   NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        facility_id               NVARCHAR(8)   NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        area_name                 NVARCHAR(50)  NOT NULL,
+        visibility_lat            FLOAT         NULL,
+        visibility_lon            FLOAT         NULL,
+        surveillance_range        INT           NULL,
+        ldb_beacon_codes_inhibited    BIT NULL,
+        pdb_ground_speed_inhibited    BIT NULL,
+        display_requested_alt_in_fdb  BIT NULL,
+        use_vfr_position_symbol       BIT NULL,
+        show_dest_departures          BIT NULL,
+        show_dest_satellite_arrivals  BIT NULL,
+        show_dest_primary_arrivals    BIT NULL,
+        underlying_airports_json      NVARCHAR(MAX) NULL,
+        ssa_airports_json             NVARCHAR(MAX) NULL,
+        tower_list_configs_json       NVARCHAR(MAX) NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_stars_areas_facility ON dbo.vnas_stars_areas (facility_id);
+    PRINT 'Created table: dbo.vnas_stars_areas';
+END
+GO
+
+-- 5. vnas_beacon_banks (781 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_beacon_banks')
+BEGIN
+    CREATE TABLE dbo.vnas_beacon_banks (
+        bank_id                   NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        facility_id               NVARCHAR(8)   NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        source_system             NVARCHAR(4)   NOT NULL,
+        category                  NVARCHAR(16)  NULL,
+        priority                  NVARCHAR(16)  NULL,
+        subset                    INT           NULL,
+        start_code                INT           NOT NULL,
+        end_code                  INT           NOT NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_beacon_banks_facility ON dbo.vnas_beacon_banks (facility_id, source_system);
+    PRINT 'Created table: dbo.vnas_beacon_banks';
+END
+GO
+
+-- 6. vnas_transceivers (~1,526 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_transceivers')
+BEGIN
+    CREATE TABLE dbo.vnas_transceivers (
+        transceiver_id            NVARCHAR(40)  NOT NULL PRIMARY KEY,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        transceiver_name          NVARCHAR(80)  NOT NULL,
+        lat                       FLOAT         NOT NULL,
+        lon                       FLOAT         NOT NULL,
+        height_msl_meters         INT           NULL,
+        height_agl_meters         INT           NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_transceivers_artcc ON dbo.vnas_transceivers (parent_artcc);
+    PRINT 'Created table: dbo.vnas_transceivers';
+END
+GO
+
+-- 7. vnas_video_map_index (15,007 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_video_map_index')
+BEGIN
+    CREATE TABLE dbo.vnas_video_map_index (
+        map_id                    NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        map_name                  NVARCHAR(100) NOT NULL,
+        short_name                NVARCHAR(50)  NULL,
+        stars_id                  NVARCHAR(16)  NULL,
+        tags_json                 NVARCHAR(MAX) NULL,
+        source_file_name          NVARCHAR(100) NULL,
+        stars_brightness_category NVARCHAR(20)  NULL,
+        stars_always_visible      BIT           NULL,
+        tdm_only                  BIT           NULL,
+        last_updated_at           DATETIME2     NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_video_map_artcc ON dbo.vnas_video_map_index (parent_artcc);
+    PRINT 'Created table: dbo.vnas_video_map_index';
+END
+GO
+
+-- 8. vnas_airport_groups (69 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_airport_groups')
+BEGIN
+    CREATE TABLE dbo.vnas_airport_groups (
+        group_id                  NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        group_name                NVARCHAR(50)  NOT NULL,
+        airport_ids_json          NVARCHAR(MAX) NOT NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    PRINT 'Created table: dbo.vnas_airport_groups';
+END
+GO
+
+-- 9. vnas_common_urls (88 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_common_urls')
+BEGIN
+    CREATE TABLE dbo.vnas_common_urls (
+        url_id                    NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        url_name                  NVARCHAR(100) NOT NULL,
+        url                       NVARCHAR(500) NOT NULL,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    PRINT 'Created table: dbo.vnas_common_urls';
+END
+GO
+
+-- 10. vnas_sync_metadata (24 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_sync_metadata')
+BEGIN
+    CREATE TABLE dbo.vnas_sync_metadata (
+        artcc_code                NVARCHAR(4)   NOT NULL PRIMARY KEY,
+        source_updated_at         DATETIME2     NULL,
+        last_import_utc           DATETIME2     NULL,
+        facilities_count          INT           NULL,
+        positions_count           INT           NULL,
+        restrictions_count        INT           NULL,
+        auto_atc_rules_count      INT           NULL,
+        import_duration_ms        INT           NULL,
+        import_status             NVARCHAR(20)  NULL
+    );
+    PRINT 'Created table: dbo.vnas_sync_metadata';
+END
+GO

--- a/database/migrations/vnas/002_vnas_restrictions_schema.sql
+++ b/database/migrations/vnas/002_vnas_restrictions_schema.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- Migration 002: vNAS Restrictions & Auto ATC Rules
+-- Source: restrictions[] and autoAtcRules[] from CRC ARTCC JSON files
+-- Design: docs/plans/2026-04-07-vnas-reference-sync-design.md
+-- ============================================================================
+
+-- 1. vnas_restrictions (1,836 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_restrictions')
+BEGIN
+    CREATE TABLE dbo.vnas_restrictions (
+        restriction_id            NVARCHAR(40)  NOT NULL PRIMARY KEY,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        owning_facility_id        NVARCHAR(8)   NOT NULL,
+        owning_sector_ids         NVARCHAR(MAX) NULL,
+        requesting_facility_id    NVARCHAR(8)   NULL,
+        requesting_sector_ids     NVARCHAR(MAX) NULL,
+        route                     NVARCHAR(200) NULL,
+        applicable_airports       NVARCHAR(MAX) NULL,
+        applicable_aircraft_types NVARCHAR(MAX) NULL,
+        flight_type               NVARCHAR(20)  NULL,
+        flow                      NVARCHAR(50)  NULL,
+        group_name                NVARCHAR(100) NULL,
+        altitude_type             NVARCHAR(30)  NULL,
+        altitude_values           NVARCHAR(MAX) NULL,
+        speed_type                NVARCHAR(20)  NULL,
+        speed_values              NVARCHAR(MAX) NULL,
+        speed_units               NVARCHAR(10)  NULL,
+        heading_type              NVARCHAR(20)  NULL,
+        heading_values            NVARCHAR(MAX) NULL,
+        location_type             NVARCHAR(10)  NULL,
+        location_value            NVARCHAR(20)  NULL,
+        notes_json                NVARCHAR(MAX) NULL,
+        display_order             INT           NOT NULL DEFAULT 0,
+        imported_utc              DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_restrictions_artcc ON dbo.vnas_restrictions (parent_artcc);
+    CREATE INDEX IX_vnas_restrictions_owning ON dbo.vnas_restrictions (owning_facility_id);
+    CREATE INDEX IX_vnas_restrictions_airports ON dbo.vnas_restrictions (parent_artcc) INCLUDE (applicable_airports, flight_type);
+    PRINT 'Created table: dbo.vnas_restrictions';
+END
+GO
+
+-- 2. vnas_auto_atc_rules (1,188 rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_auto_atc_rules')
+BEGIN
+    CREATE TABLE dbo.vnas_auto_atc_rules (
+        rule_id                       NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        parent_artcc                  NVARCHAR(4)   NOT NULL,
+        rule_name                     NVARCHAR(100) NOT NULL,
+        status                        NVARCHAR(16)  NOT NULL,
+        position_ulid                 NVARCHAR(32)  NULL,
+        route_substrings              NVARCHAR(MAX) NULL,
+        exclude_route_substrings      NVARCHAR(MAX) NULL,
+        departure_airports            NVARCHAR(MAX) NULL,
+        destination_airports          NVARCHAR(MAX) NULL,
+        min_altitude                  INT           NULL,
+        max_altitude                  INT           NULL,
+        applicable_jets               BIT NOT NULL DEFAULT 0,
+        applicable_turboprops         BIT NOT NULL DEFAULT 0,
+        applicable_props              BIT NOT NULL DEFAULT 0,
+        descent_crossing_line_json    NVARCHAR(MAX) NULL,
+        descent_altitude_value        INT           NULL,
+        descent_altitude_type         NVARCHAR(10)  NULL,
+        descent_transition_level      INT           NULL,
+        descent_is_lufl               BIT           NULL,
+        descent_lufl_station_id       NVARCHAR(4)   NULL,
+        descent_altimeter_station     NVARCHAR(8)   NULL,
+        descent_altimeter_name        NVARCHAR(50)  NULL,
+        descent_speed_value           INT           NULL,
+        descent_speed_is_mach         BIT           NULL,
+        descent_speed_type            NVARCHAR(16)  NULL,
+        crossing_fix                  NVARCHAR(10)  NULL,
+        crossing_fix_name             NVARCHAR(20)  NULL,
+        crossing_altitude_value       INT           NULL,
+        crossing_altitude_type        NVARCHAR(10)  NULL,
+        crossing_transition_level     INT           NULL,
+        crossing_is_lufl              BIT           NULL,
+        crossing_altimeter_station    NVARCHAR(8)   NULL,
+        crossing_altimeter_name       NVARCHAR(50)  NULL,
+        descend_via_star_name         NVARCHAR(20)  NULL,
+        descend_via_crossing_line_json NVARCHAR(MAX) NULL,
+        descend_via_altimeter_station NVARCHAR(8)   NULL,
+        descend_via_altimeter_name    NVARCHAR(50)  NULL,
+        precursor_rule_ids            NVARCHAR(MAX) NULL,
+        exclusionary_rule_ids         NVARCHAR(MAX) NULL,
+        imported_utc                  DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_auto_atc_parent ON dbo.vnas_auto_atc_rules (parent_artcc, status);
+    CREATE INDEX IX_vnas_auto_atc_position ON dbo.vnas_auto_atc_rules (position_ulid);
+    PRINT 'Created table: dbo.vnas_auto_atc_rules';
+END
+GO

--- a/database/migrations/vnas/003_vnas_staffing_mapping.sql
+++ b/database/migrations/vnas/003_vnas_staffing_mapping.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- Migration 003: Staffing columns on adl_boundary + position/TCP sector maps
+-- Enables 2B: enhanced controller feed parsing
+-- Design: docs/plans/2026-04-07-vnas-reference-sync-design.md
+-- ============================================================================
+
+-- 1. Staffing columns on adl_boundary
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.adl_boundary') AND name = 'is_staffed')
+BEGIN
+    ALTER TABLE dbo.adl_boundary ADD is_staffed BIT NOT NULL DEFAULT 0;
+    ALTER TABLE dbo.adl_boundary ADD staffed_by_cid INT NULL;
+    ALTER TABLE dbo.adl_boundary ADD staffed_updated_utc DATETIME2 NULL;
+    PRINT 'Added staffing columns to dbo.adl_boundary';
+END
+GO
+
+-- 2. vnas_position_sector_map (maps position ULIDs to adl_boundary rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_position_sector_map')
+BEGIN
+    CREATE TABLE dbo.vnas_position_sector_map (
+        position_ulid             NVARCHAR(32)  NOT NULL,
+        boundary_id               INT           NOT NULL,
+        boundary_code             NVARCHAR(20)  NOT NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        sector_type               NVARCHAR(16)  NOT NULL,
+        mapped_utc                DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_vnas_pos_sector PRIMARY KEY (position_ulid, boundary_id)
+    );
+    CREATE INDEX IX_vnas_pos_sector_boundary ON dbo.vnas_position_sector_map (boundary_id);
+    PRINT 'Created table: dbo.vnas_position_sector_map';
+END
+GO
+
+-- 3. vnas_tcp_sector_map (maps STARS TCP sectorIds to adl_boundary rows)
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'vnas_tcp_sector_map')
+BEGIN
+    CREATE TABLE dbo.vnas_tcp_sector_map (
+        tcp_id                    NVARCHAR(32)  NOT NULL PRIMARY KEY,
+        facility_id               NVARCHAR(8)   NOT NULL,
+        sector_id                 NVARCHAR(4)   NOT NULL,
+        boundary_id               INT           NULL,
+        boundary_code             NVARCHAR(20)  NULL,
+        parent_artcc              NVARCHAR(4)   NOT NULL,
+        mapped_utc                DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+    CREATE INDEX IX_vnas_tcp_sector_facility ON dbo.vnas_tcp_sector_map (facility_id, sector_id);
+    PRINT 'Created table: dbo.vnas_tcp_sector_map';
+END
+GO

--- a/scripts/vnas_sync/crc_parser.py
+++ b/scripts/vnas_sync/crc_parser.py
@@ -1,0 +1,438 @@
+"""
+CRC ARTCC JSON parser for vNAS sync.
+
+Reads a CRC ARTCC JSON file (from %LOCALAPPDATA%/CRC/ARTCCs/*.json)
+and returns two dicts: (facilities_payload, restrictions_payload).
+"""
+
+import json
+import copy
+
+
+def parse_artcc_json(filepath):
+    """Parse a CRC ARTCC JSON file and return (facilities_payload, restrictions_payload).
+
+    Args:
+        filepath: Path to a CRC ARTCC JSON file (e.g. ZDC.json).
+
+    Returns:
+        Tuple of (facilities_payload, restrictions_payload) dicts.
+    """
+    with open(filepath, encoding='utf-8') as f:
+        data = json.load(f)
+
+    artcc_code = data['facility']['id']
+    source_updated_at = data.get('lastUpdatedAt')
+    visibility_centers = data.get('visibilityCenters')
+    aliases_updated_at = data.get('aliasesLastUpdatedAt')
+
+    # Accumulators
+    facilities = []
+    positions = []
+    stars_tcps = []
+    stars_areas = []
+    beacon_banks = []
+
+    # Walk the facility hierarchy recursively
+    _walk_facility(
+        data['facility'],
+        artcc_code=artcc_code,
+        parent_facility_id=None,
+        depth=0,
+        source_updated_at=source_updated_at,
+        visibility_centers=visibility_centers,
+        aliases_updated_at=aliases_updated_at,
+        facilities=facilities,
+        positions=positions,
+        stars_tcps=stars_tcps,
+        stars_areas=stars_areas,
+        beacon_banks=beacon_banks,
+    )
+
+    # Top-level transceivers
+    transceivers = []
+    for tx in data.get('transceivers', []):
+        loc = tx.get('location', {})
+        transceivers.append({
+            'transceiver_id': tx.get('id'),
+            'parent_artcc': artcc_code,
+            'transceiver_name': tx.get('name'),
+            'lat': loc.get('lat'),
+            'lon': loc.get('lon'),
+            'height_msl_meters': tx.get('heightMslMeters'),
+            'height_agl_meters': tx.get('heightAglMeters'),
+        })
+
+    # Top-level video maps
+    video_maps = []
+    for vm in data.get('videoMaps', []):
+        video_maps.append({
+            'map_id': vm.get('id'),
+            'parent_artcc': artcc_code,
+            'map_name': vm.get('name'),
+            'short_name': vm.get('shortName'),
+            'stars_id': vm.get('starsId'),
+            'tags_json': vm.get('tags', []),
+            'source_file_name': vm.get('sourceFileName'),
+            'stars_brightness_category': vm.get('starsBrightnessCategory'),
+            'stars_always_visible': vm.get('starsAlwaysVisible', False),
+            'tdm_only': vm.get('tdmOnly', False),
+            'last_updated_at': vm.get('lastUpdatedAt'),
+        })
+
+    # Top-level airport groups
+    airport_groups = []
+    for ag in data.get('airportGroups', []):
+        airport_groups.append({
+            'group_id': ag.get('id'),
+            'parent_artcc': artcc_code,
+            'group_name': ag.get('name'),
+            'airport_ids_json': ag.get('airportIds', []),
+        })
+
+    # Top-level common URLs
+    common_urls = []
+    for cu in data.get('commonUrls', []):
+        common_urls.append({
+            'url_id': cu.get('id'),
+            'parent_artcc': artcc_code,
+            'url_name': cu.get('name'),
+            'url': cu.get('url'),
+        })
+
+    facilities_payload = {
+        'artcc_code': artcc_code,
+        'source_updated_at': source_updated_at,
+        'facilities': facilities,
+        'positions': positions,
+        'stars_tcps': stars_tcps,
+        'stars_areas': stars_areas,
+        'beacon_banks': beacon_banks,
+        'transceivers': transceivers,
+        'video_maps': video_maps,
+        'airport_groups': airport_groups,
+        'common_urls': common_urls,
+    }
+
+    # Restrictions payload
+    restrictions = []
+    for r in data.get('restrictions', []):
+        alt_r = r.get('altitudeRestriction') or {}
+        spd_r = r.get('speedRestriction') or {}
+        hdg_r = r.get('headingRestriction') or {}
+        loc_r = r.get('locationRestriction') or {}
+
+        restrictions.append({
+            'restriction_id': r.get('id'),
+            'parent_artcc': artcc_code,
+            'owning_facility_id': r.get('owningFacilityId'),
+            'owning_sector_ids': r.get('owningSectorIds', []),
+            'requesting_facility_id': r.get('requestingFacilityId'),
+            'requesting_sector_ids': r.get('requestingSectorIds', []),
+            'route': r.get('route'),
+            'applicable_airports': r.get('applicableAirports', []),
+            'applicable_aircraft_types': r.get('applicableAircraftTypes', []),
+            'flight_type': r.get('flightType'),
+            'flow': r.get('flow'),
+            'group_name': r.get('groupName'),
+            'altitude_type': alt_r.get('type'),
+            'altitude_values': alt_r.get('altitudes'),
+            'speed_type': spd_r.get('type'),
+            'speed_values': spd_r.get('speeds'),
+            'speed_units': spd_r.get('units'),
+            'heading_type': hdg_r.get('type'),
+            'heading_values': hdg_r.get('headings'),
+            'location_type': loc_r.get('type'),
+            'location_value': loc_r.get('location'),
+            'notes_json': r.get('notes', []),
+            'display_order': r.get('displayOrder', 0),
+        })
+
+    # Auto ATC rules
+    auto_atc_rules = []
+    for rule in data.get('autoAtcRules', []):
+        criteria = rule.get('criteria', {})
+
+        # Descent restriction (line-based)
+        dr = rule.get('descentRestriction')
+        # Descent crossing restriction (fix-based)
+        dcr = rule.get('descentCrossingRestriction')
+        # Descend via
+        dv = rule.get('descendVia')
+
+        # descentRestriction fields
+        dr_crossing_line = None
+        dr_alt_value = None
+        dr_alt_type = None
+        dr_transition = None
+        dr_is_lufl = None
+        dr_lufl_station = None
+        dr_altimeter_station = None
+        dr_altimeter_name = None
+        dr_speed_value = None
+        dr_speed_is_mach = None
+        dr_speed_type = None
+
+        if dr is not None:
+            dr_crossing_line = dr.get('crossingLine')
+            alt_c = dr.get('altitudeConstraint') or {}
+            dr_alt_value = alt_c.get('value')
+            dr_alt_type = alt_c.get('constraintType')
+            dr_transition = alt_c.get('transitionLevel')
+            dr_is_lufl = alt_c.get('isLufl')
+            dr_lufl_station = alt_c.get('luflStationId')
+            alt_s = dr.get('altimeterStation') or {}
+            dr_altimeter_station = alt_s.get('stationId')
+            dr_altimeter_name = alt_s.get('stationName')
+            spd_c = dr.get('speedConstraint') or {}
+            dr_speed_value = spd_c.get('value')
+            dr_speed_is_mach = spd_c.get('isMach')
+            dr_speed_type = spd_c.get('constraintType')
+
+        # descentCrossingRestriction fields
+        cr_fix = None
+        cr_fix_name = None
+        cr_alt_value = None
+        cr_alt_type = None
+        cr_transition = None
+        cr_is_lufl = None
+        cr_altimeter_station = None
+        cr_altimeter_name = None
+
+        if dcr is not None:
+            cr_fix = dcr.get('crossingFix')
+            cr_fix_name = dcr.get('crossingFixName')
+            alt_c = dcr.get('altitudeConstraint') or {}
+            cr_alt_value = alt_c.get('value')
+            cr_alt_type = alt_c.get('constraintType')
+            cr_transition = alt_c.get('transitionLevel')
+            cr_is_lufl = alt_c.get('isLufl')
+            alt_s = dcr.get('altimeterStation') or {}
+            cr_altimeter_station = alt_s.get('stationId')
+            cr_altimeter_name = alt_s.get('stationName')
+
+        # descendVia fields
+        dv_star_name = None
+        dv_crossing_line = None
+        dv_altimeter_station = None
+        dv_altimeter_name = None
+
+        if dv is not None:
+            dv_star_name = dv.get('starName')
+            dv_crossing_line = dv.get('crossingLine')
+            alt_s = dv.get('altimeterStation') or {}
+            dv_altimeter_station = alt_s.get('stationId')
+            dv_altimeter_name = alt_s.get('stationName')
+
+        auto_atc_rules.append({
+            'rule_id': rule.get('id'),
+            'parent_artcc': artcc_code,
+            'rule_name': rule.get('name'),
+            'status': rule.get('status'),
+            'position_ulid': rule.get('positionId'),
+            'route_substrings': criteria.get('routeSubstrings', []),
+            'exclude_route_substrings': criteria.get('excludeRouteSubstrings', []),
+            'departure_airports': criteria.get('departures', []),
+            'destination_airports': criteria.get('destinations', []),
+            'min_altitude': criteria.get('minAltitude'),
+            'max_altitude': criteria.get('maxAltitude'),
+            'applicable_jets': criteria.get('applicableToJets', False),
+            'applicable_turboprops': criteria.get('applicableToTurboprops', False),
+            'applicable_props': criteria.get('applicableToProps', False),
+            # descentRestriction fields
+            'descent_crossing_line_json': dr_crossing_line,
+            'descent_altitude_value': dr_alt_value,
+            'descent_altitude_type': dr_alt_type,
+            'descent_transition_level': dr_transition,
+            'descent_is_lufl': dr_is_lufl,
+            'descent_lufl_station_id': dr_lufl_station,
+            'descent_altimeter_station': dr_altimeter_station,
+            'descent_altimeter_name': dr_altimeter_name,
+            'descent_speed_value': dr_speed_value,
+            'descent_speed_is_mach': dr_speed_is_mach,
+            'descent_speed_type': dr_speed_type,
+            # descentCrossingRestriction fields
+            'crossing_fix': cr_fix,
+            'crossing_fix_name': cr_fix_name,
+            'crossing_altitude_value': cr_alt_value,
+            'crossing_altitude_type': cr_alt_type,
+            'crossing_transition_level': cr_transition,
+            'crossing_is_lufl': cr_is_lufl,
+            'crossing_altimeter_station': cr_altimeter_station,
+            'crossing_altimeter_name': cr_altimeter_name,
+            # descendVia fields
+            'descend_via_star_name': dv_star_name,
+            'descend_via_crossing_line_json': dv_crossing_line,
+            'descend_via_altimeter_station': dv_altimeter_station,
+            'descend_via_altimeter_name': dv_altimeter_name,
+            # Rule linkage
+            'precursor_rule_ids': rule.get('precursorRules', []),
+            'exclusionary_rule_ids': rule.get('exclusionaryRules', []),
+        })
+
+    restrictions_payload = {
+        'artcc_code': artcc_code,
+        'restrictions': restrictions,
+        'auto_atc_rules': auto_atc_rules,
+    }
+
+    return facilities_payload, restrictions_payload
+
+
+def _walk_facility(fac, artcc_code, parent_facility_id, depth,
+                   source_updated_at, visibility_centers, aliases_updated_at,
+                   facilities, positions, stars_tcps, stars_areas, beacon_banks):
+    """Recursively walk facility hierarchy, accumulating into output lists."""
+    fac_id = fac.get('id')
+    fac_type = fac.get('type')
+
+    # Detect which config subsystems are present
+    eram_config = fac.get('eramConfiguration')
+    stars_config = fac.get('starsConfiguration')
+    flight_strips_config = fac.get('flightStripsConfiguration')
+    tower_cab_config = fac.get('towerCabConfiguration')
+    asdex_config = fac.get('asdexConfiguration')
+    tdls_config = fac.get('tdlsConfiguration')
+
+    # Extract beacon banks from ERAM config
+    if eram_config:
+        for bank in eram_config.get('beaconCodeBanks', []):
+            beacon_banks.append({
+                'bank_id': bank.get('id'),
+                'facility_id': fac_id,
+                'parent_artcc': artcc_code,
+                'source_system': 'ERAM',
+                'category': bank.get('category'),
+                'priority': bank.get('priority'),
+                'subset': bank.get('subset'),
+                'start_code': bank.get('start'),
+                'end_code': bank.get('end'),
+            })
+
+    # Extract STARS sub-objects (tcps, areas, beacon banks)
+    if stars_config:
+        for tcp in stars_config.get('tcps', []):
+            stars_tcps.append({
+                'tcp_id': tcp.get('id'),
+                'facility_id': fac_id,
+                'parent_artcc': artcc_code,
+                'subset': tcp.get('subset'),
+                'sector_id': tcp.get('sectorId'),
+                'parent_tcp_id': tcp.get('parentTcpId'),
+                'terminal_sector': tcp.get('terminalSector'),
+            })
+
+        for area in stars_config.get('areas', []):
+            vc = area.get('visibilityCenter', {})
+            stars_areas.append({
+                'area_id': area.get('id'),
+                'facility_id': fac_id,
+                'parent_artcc': artcc_code,
+                'area_name': area.get('name'),
+                'visibility_lat': vc.get('lat'),
+                'visibility_lon': vc.get('lon'),
+                'surveillance_range': area.get('surveillanceRange'),
+                'ldb_beacon_codes_inhibited': area.get('ldbBeaconCodesInhibited', False),
+                'pdb_ground_speed_inhibited': area.get('pdbGroundSpeedInhibited', False),
+                'display_requested_alt_in_fdb': area.get('displayRequestedAltInFdb', False),
+                'use_vfr_position_symbol': area.get('useVfrPositionSymbol', False),
+                'show_dest_departures': area.get('showDestinationDepartures', False),
+                'show_dest_satellite_arrivals': area.get('showDestinationSatelliteArrivals', False),
+                'show_dest_primary_arrivals': area.get('showDestinationPrimaryArrivals', False),
+                'underlying_airports_json': area.get('underlyingAirports', []),
+                'ssa_airports_json': area.get('ssaAirports', []),
+                'tower_list_configs_json': area.get('towerListConfigurations', []),
+            })
+
+        for bank in stars_config.get('beaconCodeBanks', []):
+            beacon_banks.append({
+                'bank_id': bank.get('id'),
+                'facility_id': fac_id,
+                'parent_artcc': artcc_code,
+                'source_system': 'STARS',
+                'category': bank.get('type'),  # STARS 'type' mapped to 'category'
+                'priority': None,  # STARS has no priority
+                'subset': bank.get('subset'),
+                'start_code': bank.get('start'),
+                'end_code': bank.get('end'),
+            })
+
+    # Build stripped config copies for storage on the facility row
+    eram_config_stripped = None
+    if eram_config:
+        eram_config_stripped = copy.deepcopy(eram_config)
+        eram_config_stripped.pop('beaconCodeBanks', None)
+
+    stars_config_stripped = None
+    if stars_config:
+        stars_config_stripped = copy.deepcopy(stars_config)
+        stars_config_stripped.pop('tcps', None)
+        stars_config_stripped.pop('areas', None)
+        stars_config_stripped.pop('beaconCodeBanks', None)
+
+    # Build facility row
+    fac_row = {
+        'facility_id': fac_id,
+        'facility_name': fac.get('name'),
+        'facility_type': fac_type,
+        'parent_artcc': artcc_code,
+        'parent_facility_id': parent_facility_id,
+        'hierarchy_depth': depth,
+        'neighboring_facility_ids': fac.get('neighboringFacilityIds', []),
+        'non_nas_facility_ids': fac.get('nonNasFacilityIds', []),
+        'has_eram': eram_config is not None,
+        'has_stars': stars_config is not None,
+        'has_flight_strips': flight_strips_config is not None,
+        'has_tower_cab': tower_cab_config is not None,
+        'has_asdex': asdex_config is not None,
+        'has_tdls': tdls_config is not None,
+        'eram_config_json': eram_config_stripped,
+        'stars_config_json': stars_config_stripped,
+        'flight_strips_json': flight_strips_config,
+        'tower_cab_json': tower_cab_config,
+        'asdex_config_json': asdex_config,
+        'tdls_config_json': tdls_config,
+        'visibility_centers_json': visibility_centers if depth == 0 else None,
+        'aliases_updated_at': aliases_updated_at if depth == 0 else None,
+        'source_artcc': artcc_code,
+        'source_updated_at': source_updated_at,
+    }
+    facilities.append(fac_row)
+
+    # Extract positions
+    for pos in fac.get('positions', []):
+        eram_pos = pos.get('eramConfiguration') or {}
+        stars_pos = pos.get('starsConfiguration') or {}
+
+        positions.append({
+            'position_ulid': pos.get('id'),
+            'facility_id': fac_id,
+            'parent_artcc': artcc_code,
+            'position_name': pos.get('name'),
+            'callsign': pos.get('callsign'),
+            'radio_name': pos.get('radioName'),
+            'frequency_hz': pos.get('frequency'),
+            'starred': pos.get('starred', False),
+            'eram_sector_id': eram_pos.get('sectorId'),
+            'stars_area_id': stars_pos.get('areaId'),
+            'stars_tcp_id': stars_pos.get('tcpId'),
+            'stars_color_set': stars_pos.get('colorSet'),
+            'transceiver_ids_json': pos.get('transceiverIds', []),
+        })
+
+    # Recurse into child facilities
+    for child in fac.get('childFacilities', []):
+        _walk_facility(
+            child,
+            artcc_code=artcc_code,
+            parent_facility_id=fac_id,
+            depth=depth + 1,
+            source_updated_at=source_updated_at,
+            visibility_centers=None,  # only ARTCC-level
+            aliases_updated_at=None,  # only ARTCC-level
+            facilities=facilities,
+            positions=positions,
+            stars_tcps=stars_tcps,
+            stars_areas=stars_areas,
+            beacon_banks=beacon_banks,
+        )

--- a/scripts/vnas_sync/requirements.txt
+++ b/scripts/vnas_sync/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+watchdog>=4.0.0

--- a/scripts/vnas_sync/vnas_crc_watcher.py
+++ b/scripts/vnas_sync/vnas_crc_watcher.py
@@ -1,0 +1,334 @@
+"""
+vNAS CRC file watcher and PERTI API client.
+
+Monitors %LOCALAPPDATA%/CRC/ARTCCs/*.json for changes,
+parses them via crc_parser, and POSTs to PERTI ingest endpoints.
+
+Usage:
+    python vnas_crc_watcher.py [--once] [--artcc ZDC] [--debug] [--dry-run]
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+# Import sibling parser module
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from crc_parser import parse_artcc_json
+
+logger = logging.getLogger('vnas_crc_watcher')
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+CRC_DIR = os.path.join(os.environ.get('LOCALAPPDATA', ''), 'CRC', 'ARTCCs')
+STATE_DIR = os.path.join(os.path.expanduser('~'), '.perti')
+STATE_FILE = os.path.join(STATE_DIR, 'vnas_sync_state.json')
+
+DEBOUNCE_SECONDS = 5
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+def load_state():
+    """Load the lastUpdatedAt state file, returning a dict keyed by ARTCC code."""
+    if os.path.isfile(STATE_FILE):
+        try:
+            with open(STATE_FILE, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning('Failed to read state file %s: %s', STATE_FILE, exc)
+    return {}
+
+
+def save_state(state):
+    """Persist the state dict to disk."""
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(STATE_FILE, 'w', encoding='utf-8') as f:
+        json.dump(state, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Core sync logic
+# ---------------------------------------------------------------------------
+
+def read_last_updated_at(filepath):
+    """Read and return the lastUpdatedAt value from a CRC JSON file."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return data.get('lastUpdatedAt')
+
+
+def sync_artcc(filepath, state, base_url, api_key, dry_run=False):
+    """Parse an ARTCC JSON file and POST to PERTI if changed.
+
+    Returns True if a sync was performed (or would have been in dry-run).
+    """
+    artcc_code = Path(filepath).stem  # e.g. "ZDC" from "ZDC.json"
+
+    try:
+        current_updated = read_last_updated_at(filepath)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error('Failed to read %s: %s', filepath, exc)
+        return False
+
+    saved_updated = state.get(artcc_code)
+
+    if saved_updated == current_updated:
+        logger.debug('%s unchanged (lastUpdatedAt=%s), skipping', artcc_code, current_updated)
+        return False
+
+    logger.info('Processing %s (lastUpdatedAt %s -> %s)', artcc_code,
+                saved_updated or '(none)', current_updated)
+
+    # Parse
+    try:
+        facilities_payload, restrictions_payload = parse_artcc_json(filepath)
+    except Exception as exc:
+        logger.error('Parse failed for %s: %s', filepath, exc)
+        return False
+
+    # Log payload sizes
+    logger.info(
+        '%s payload: %d facilities, %d positions, %d stars_tcps, %d stars_areas, '
+        '%d beacon_banks, %d transceivers, %d video_maps, %d airport_groups, '
+        '%d common_urls, %d restrictions, %d auto_atc_rules',
+        artcc_code,
+        len(facilities_payload.get('facilities', [])),
+        len(facilities_payload.get('positions', [])),
+        len(facilities_payload.get('stars_tcps', [])),
+        len(facilities_payload.get('stars_areas', [])),
+        len(facilities_payload.get('beacon_banks', [])),
+        len(facilities_payload.get('transceivers', [])),
+        len(facilities_payload.get('video_maps', [])),
+        len(facilities_payload.get('airport_groups', [])),
+        len(facilities_payload.get('common_urls', [])),
+        len(restrictions_payload.get('restrictions', [])),
+        len(restrictions_payload.get('auto_atc_rules', [])),
+    )
+
+    if dry_run:
+        logger.info('[DRY RUN] Would POST facilities to %s/api/swim/v1/ingest/vnas/facilities',
+                     base_url)
+        logger.info('[DRY RUN] Would POST restrictions to %s/api/swim/v1/ingest/vnas/restrictions',
+                     base_url)
+    else:
+        headers = {
+            'Content-Type': 'application/json',
+            'X-API-Key': api_key,
+        }
+
+        # POST facilities
+        fac_url = f'{base_url}/api/swim/v1/ingest/vnas/facilities'
+        try:
+            resp = requests.post(fac_url, json=facilities_payload, headers=headers, timeout=60)
+            if resp.status_code == 200:
+                logger.info('%s facilities POST OK (200)', artcc_code)
+            else:
+                logger.error('%s facilities POST failed (%d): %s',
+                             artcc_code, resp.status_code, resp.text[:500])
+        except requests.RequestException as exc:
+            logger.error('%s facilities POST error: %s', artcc_code, exc)
+
+        # POST restrictions
+        rst_url = f'{base_url}/api/swim/v1/ingest/vnas/restrictions'
+        try:
+            resp = requests.post(rst_url, json=restrictions_payload, headers=headers, timeout=60)
+            if resp.status_code == 200:
+                logger.info('%s restrictions POST OK (200)', artcc_code)
+            else:
+                logger.error('%s restrictions POST failed (%d): %s',
+                             artcc_code, resp.status_code, resp.text[:500])
+        except requests.RequestException as exc:
+            logger.error('%s restrictions POST error: %s', artcc_code, exc)
+
+    # Update state
+    if current_updated:
+        state[artcc_code] = current_updated
+        save_state(state)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# --once mode
+# ---------------------------------------------------------------------------
+
+def run_once(args, base_url, api_key):
+    """Process all (or specified) ARTCCs once and exit."""
+    state = load_state()
+
+    if args.artcc:
+        files = [os.path.join(CRC_DIR, f'{args.artcc}.json')]
+        if not os.path.isfile(files[0]):
+            logger.error('ARTCC file not found: %s', files[0])
+            return 1
+        # If no saved state for this ARTCC, force-process it
+        if args.artcc not in state:
+            logger.info('No saved state for %s, will process unconditionally', args.artcc)
+    else:
+        files = sorted(
+            os.path.join(CRC_DIR, f)
+            for f in os.listdir(CRC_DIR)
+            if f.endswith('.json')
+        )
+
+    if not files:
+        logger.warning('No ARTCC JSON files found in %s', CRC_DIR)
+        return 1
+
+    processed = 0
+    skipped = 0
+
+    for filepath in files:
+        artcc_code = Path(filepath).stem
+        if args.artcc and args.artcc not in state:
+            # Force processing by temporarily removing saved state
+            pass  # state already lacks the key, sync_artcc will detect mismatch
+        synced = sync_artcc(filepath, state, base_url, api_key, dry_run=args.dry_run)
+        if synced:
+            processed += 1
+        else:
+            skipped += 1
+
+    logger.info('Done: %d processed, %d skipped (unchanged)', processed, skipped)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Watch mode (watchdog)
+# ---------------------------------------------------------------------------
+
+class ArtccFileHandler(FileSystemEventHandler):
+    """Handles .json file modification events in the CRC ARTCCs directory."""
+
+    def __init__(self, base_url, api_key, dry_run=False, artcc_filter=None):
+        super().__init__()
+        self.base_url = base_url
+        self.api_key = api_key
+        self.dry_run = dry_run
+        self.artcc_filter = artcc_filter
+        self.state = load_state()
+        self._last_sync = {}  # artcc_code -> timestamp for debounce
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        if not event.src_path.endswith('.json'):
+            return
+
+        artcc_code = Path(event.src_path).stem
+
+        if self.artcc_filter and artcc_code != self.artcc_filter:
+            return
+
+        # Debounce: skip if synced within DEBOUNCE_SECONDS
+        now = time.time()
+        last = self._last_sync.get(artcc_code, 0)
+        if now - last < DEBOUNCE_SECONDS:
+            logger.debug('Debounce: ignoring %s change (%.1fs since last sync)',
+                         artcc_code, now - last)
+            return
+
+        logger.debug('File change detected: %s', event.src_path)
+
+        try:
+            synced = sync_artcc(event.src_path, self.state, self.base_url,
+                                self.api_key, dry_run=self.dry_run)
+            if synced:
+                self._last_sync[artcc_code] = time.time()
+        except Exception:
+            logger.exception('Error processing %s', event.src_path)
+
+
+def run_watch(args, base_url, api_key):
+    """Watch CRC ARTCCs directory for file changes."""
+    if not os.path.isdir(CRC_DIR):
+        logger.error('CRC ARTCCs directory not found: %s', CRC_DIR)
+        return 1
+
+    handler = ArtccFileHandler(
+        base_url=base_url,
+        api_key=api_key,
+        dry_run=args.dry_run,
+        artcc_filter=args.artcc,
+    )
+    observer = Observer()
+    observer.schedule(handler, CRC_DIR, recursive=False)
+    observer.start()
+
+    logger.info('Watching %s for changes (Ctrl+C to stop)', CRC_DIR)
+    if args.artcc:
+        logger.info('Filtering to ARTCC: %s', args.artcc)
+    if args.dry_run:
+        logger.info('Dry-run mode: no HTTP POSTs will be made')
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info('Stopping watcher...')
+        observer.stop()
+    observer.join()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='vNAS CRC file watcher - syncs ARTCC data to PERTI',
+    )
+    parser.add_argument('--once', action='store_true',
+                        help='Process all (or specified) ARTCCs once and exit')
+    parser.add_argument('--artcc', type=str, default=None,
+                        help='Only process this one ARTCC (e.g. ZDC)')
+    parser.add_argument('--debug', action='store_true',
+                        help='Enable verbose debug logging')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Parse and log but skip HTTP POSTs')
+    args = parser.parse_args()
+
+    # Logging setup
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+    )
+
+    # Configuration
+    base_url = os.environ.get('PERTI_API_URL', 'https://perti.vatcscc.org').rstrip('/')
+    api_key = os.environ.get('PERTI_API_KEY', '')
+
+    if not api_key and not args.dry_run:
+        logger.error('PERTI_API_KEY environment variable is required (or use --dry-run)')
+        return 1
+
+    if not os.path.isdir(CRC_DIR):
+        logger.error('CRC ARTCCs directory not found: %s', CRC_DIR)
+        return 1
+
+    logger.info('PERTI API URL: %s', base_url)
+    logger.info('CRC ARTCCs dir: %s', CRC_DIR)
+
+    if args.once:
+        return run_once(args, base_url, api_key)
+    else:
+        return run_watch(args, base_url, api_key)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fixed column name mismatches across all 9 broken VATSWIM reference API endpoints that were returning 500 errors
- PostGIS endpoints (airports, airspace, navigation, facilities, hierarchy, utilities): corrected `icao_code`→`icao_id`, `faa_lid`→`iata_id`, `name`→`airport_name`, `latitude`→`lat`, `longitude`→`lon`, `artcc_name`→`fir_name`, `floor_fl`→`floor_altitude`, `ceiling_fl`→`ceiling_altitude`, and more
- Azure SQL endpoints (airlines, aircraft): corrected `icao_code`→`icao`, `iata_code`→`iata`, `TypeName`→`Model_FAA`, `WeightClass`→`FAA_Weight`, etc.
- MySQL endpoint (routes): reordered bootstrap to load config.php+connect.php before auth.php, preventing PERTI_SWIM_ONLY from skipping MySQL

## Test plan
- [ ] Test airlines endpoint: `/api/swim/v1/reference/airlines?search=United`
- [ ] Test aircraft endpoint: `/api/swim/v1/reference/aircraft/types?search=Boeing`
- [ ] Test airports endpoint: `/api/swim/v1/reference/airports/KJFK`
- [ ] Test airspace endpoint: `/api/swim/v1/reference/airspace/boundaries?type=artcc`
- [ ] Test navigation endpoint: `/api/swim/v1/reference/navigation/fixes/VANZE`
- [ ] Test facilities endpoint: `/api/swim/v1/reference/facilities/centers`
- [ ] Test hierarchy endpoint: `/api/swim/v1/reference/hierarchy/search?q=JFK`
- [ ] Test routes endpoint: `/api/swim/v1/reference/routes/popular?origin=KJFK&dest=KLAX`
- [ ] Test utilities endpoint: `/api/swim/v1/reference/utilities/bearing?from=KJFK&to=KLAX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)