### PR TITLE
fix(playbook): widen ARTCC columns for 4-char ICAO codes

### DIFF
--- a/assets/js/playbook.js
+++ b/assets/js/playbook.js
@@ -1329,11 +1329,11 @@
         if (hasGroups) html += '<th style="width:8px;padding:0;"></th>';
         html += '<th style="width:8%">' + t('playbook.table.origin') + '</th>';
         html += '<th style="width:3.5%">' + t('playbook.table.tracon') + '</th>';
-        html += '<th style="width:3.5%">' + t('playbook.table.artcc') + '</th>';
+        html += '<th style="width:4.5%">' + t('playbook.table.artcc') + '</th>';
         html += '<th>' + t('playbook.routeString') + '</th>';
         html += '<th style="width:8%">' + t('playbook.table.dest') + '</th>';
         html += '<th style="width:3.5%">' + t('playbook.table.tracon') + '</th>';
-        html += '<th style="width:3.5%">' + t('playbook.table.artcc') + '</th>';
+        html += '<th style="width:4.5%">' + t('playbook.table.artcc') + '</th>';
         html += '<th style="width:7%">' + t('playbook.table.traversed') + '</th>';
         html += '<th style="width:3%">' + t('playbook.table.remarks') + '</th>';
         html += '</tr></thead><tbody>';
@@ -1433,10 +1433,10 @@
         html += '<table class="pb-route-table"><thead><tr>';
         html += '<th class="pb-route-check" style="width:24px"><input type="checkbox" id="pb_check_all"></th>';
         html += '<th style="width:10%">' + t('playbook.table.origin') + '</th>';
-        html += '<th style="width:5%">' + t('playbook.table.artcc') + '</th>';
+        html += '<th style="width:6%">' + t('playbook.table.artcc') + '</th>';
         html += '<th>' + t('playbook.routeString') + '</th>';
         html += '<th style="width:10%">' + t('playbook.table.dest') + '</th>';
-        html += '<th style="width:5%">' + t('playbook.table.artcc') + '</th>';
+        html += '<th style="width:6%">' + t('playbook.table.artcc') + '</th>';
         html += '<th style="width:7%">' + t('playbook.table.traversed') + '</th>';
         html += '</tr></thead><tbody>';
 


### PR DESCRIPTION
## Summary
- Widened ARTCC columns in the playbook route detail table to prevent awkward word-wrapping of 4-character international FIR codes (CZUL, EGTT, etc.) with trailing commas
- Detail view: 3.5% → 4.5%, consolidated view: 5% → 6%
- Extra width absorbed by the flexible route string column

## Test plan
- [ ] Open playbook.php with routes containing 4-char ICAO ARTCC codes (e.g. CZUL, EGTT)
- [ ] Verify ARTCC column text no longer wraps mid-word
- [ ] Verify route string column still has adequate space

🤖 Generated with [Claude Code](https://claude.com/claude-code)