### PR TITLE
Fix splits API 500 error and step 2 UI usability

### DIFF
--- a/api/splits/active.php
+++ b/api/splits/active.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/connect_adl.php';
 
 if (!$conn_adl) {
     http_response_code(500);
-    echo json_encode(['error' => 'DB connection failed', 'details' => $conn_adl_error]);
+    echo json_encode(['error' => 'DB connection failed', 'details' => adl_sql_error_message()]);
     exit;
 }
 

--- a/api/splits/configs.php
+++ b/api/splits/configs.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/connect_adl.php';
 
 if (!$conn_adl) {
     http_response_code(500);
-    echo json_encode(['error' => 'DB connection failed', 'details' => $conn_adl_error]);
+    echo json_encode(['error' => 'DB connection failed', 'details' => adl_sql_error_message()]);
     exit;
 }
 
@@ -182,6 +182,7 @@ if ($method === 'POST') {
     $created_by = $input['created_by'] ?? 'system';
     
     // Handle datetime - convert from datetime-local format if needed
+    // Note: start_time_utc and end_time_utc are NOT NULL on production, default to current time
     $start_time = null;
     $end_time = null;
     if (!empty($input['start_time_utc'])) {
@@ -192,13 +193,14 @@ if ($method === 'POST') {
         $end_time = str_replace('T', ' ', $input['end_time_utc']);
         if (strlen($end_time) === 16) $end_time .= ':00';
     }
-    
+
     $positions = $input['positions'] ?? [];
-    
+
     // Insert config and get ID in one query using OUTPUT clause
-    $sql = "INSERT INTO splits_configs (artcc, config_name, start_time_utc, end_time_utc, status, created_by, [source], created_at, updated_at)
+    // Use ISNULL to handle NOT NULL constraint on start/end times
+    $sql = "INSERT INTO splits_configs (artcc, config_name, start_time_utc, end_time_utc, status, created_by, created_at, updated_at)
             OUTPUT INSERTED.id
-            VALUES (?, ?, ?, ?, ?, ?, 'perti', GETUTCDATE(), GETUTCDATE())";
+            VALUES (?, ?, ISNULL(?, GETUTCDATE()), ISNULL(?, DATEADD(HOUR, 4, GETUTCDATE())), ?, ?, GETUTCDATE(), GETUTCDATE())";
 
     $stmt = sqlsrv_query($conn_adl, $sql, [$artcc, $config_name, $start_time, $end_time, $status, $created_by]);
     
@@ -301,26 +303,24 @@ if ($method === 'PUT') {
         $params[] = $input['status'];
     }
     if (array_key_exists('start_time_utc', $input)) {
-        $updates[] = 'start_time_utc = ?';
         $start = $input['start_time_utc'];
         if (!empty($start)) {
             $start = str_replace('T', ' ', $start);
             if (strlen($start) === 16) $start .= ':00';
-        } else {
-            $start = null;
+            $updates[] = 'start_time_utc = ?';
+            $params[] = $start;
         }
-        $params[] = $start;
+        // Skip if empty/null — column is NOT NULL, keep existing value
     }
     if (array_key_exists('end_time_utc', $input)) {
-        $updates[] = 'end_time_utc = ?';
         $end = $input['end_time_utc'];
         if (!empty($end)) {
             $end = str_replace('T', ' ', $end);
             if (strlen($end) === 16) $end .= ':00';
-        } else {
-            $end = null;
+            $updates[] = 'end_time_utc = ?';
+            $params[] = $end;
         }
-        $params[] = $end;
+        // Skip if empty/null — column is NOT NULL, keep existing value
     }
 
     // Always update updated_at

--- a/api/splits/scheduled.php
+++ b/api/splits/scheduled.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/connect_adl.php';
 
 if (!$conn_adl) {
     http_response_code(500);
-    echo json_encode(['error' => 'DB connection failed', 'details' => $conn_adl_error]);
+    echo json_encode(['error' => 'DB connection failed', 'details' => adl_sql_error_message()]);
     exit;
 }
 
@@ -140,26 +140,24 @@ if ($method === 'PUT') {
         $params[] = $input['status'];
     }
     if (array_key_exists('start_time_utc', $input)) {
-        $updates[] = 'start_time_utc = ?';
         $start = $input['start_time_utc'];
         if (!empty($start)) {
             $start = str_replace('T', ' ', $start);
             if (strlen($start) === 16) $start .= ':00';
-        } else {
-            $start = null;
+            $updates[] = 'start_time_utc = ?';
+            $params[] = $start;
         }
-        $params[] = $start;
+        // Skip if empty/null — column is NOT NULL, keep existing value
     }
     if (array_key_exists('end_time_utc', $input)) {
-        $updates[] = 'end_time_utc = ?';
         $end = $input['end_time_utc'];
         if (!empty($end)) {
             $end = str_replace('T', ' ', $end);
             if (strlen($end) === 16) $end .= ':00';
-        } else {
-            $end = null;
+            $updates[] = 'end_time_utc = ?';
+            $params[] = $end;
         }
-        $params[] = $end;
+        // Skip if empty/null — column is NOT NULL, keep existing value
     }
 
     // Always update updated_at

--- a/assets/js/splits.js
+++ b/assets/js/splits.js
@@ -5042,6 +5042,9 @@ const SplitsController = {
                 this.disableSplitMapSelection();
             }
 
+            // Restore full sector layers (remove ARTCC filter)
+            this._clearSectorLayerFilters();
+
             if (this.currentStep === 3) {
                 this.populateReviewStep();
             }
@@ -5532,7 +5535,9 @@ const SplitsController = {
     },
 
     enableSectorLayersForSidePanel() {
-        // Show sector layers with low-opacity fill when side panel is active
+        const artcc = (this.currentConfig.artcc || '').toLowerCase();
+
+        // Show sector layers filtered to the selected ARTCC only
         ['high', 'low', 'superhigh'].forEach(layer => {
             const checkbox = document.getElementById(`layer-${layer}`);
             if (checkbox && !checkbox.checked) {
@@ -5551,6 +5556,86 @@ const SplitsController = {
             if (lineBtn && !lineBtn.classList.contains('active')) {
                 lineBtn.classList.add('active');
                 this.toggleLayerLine(layer, true);
+            }
+
+            // Apply ARTCC filter to fill and line layers (source features have 'artcc' property)
+            if (artcc && this.map) {
+                const artccFilter = ['==', ['downcase', ['get', 'artcc']], artcc];
+                if (this.map.getLayer(`${layer}-fill`)) this.map.setFilter(`${layer}-fill`, artccFilter);
+                if (this.map.getLayer(`${layer}-lines`)) this.map.setFilter(`${layer}-lines`, artccFilter);
+            }
+
+            // Rebuild label source with only this ARTCC's features
+            if (artcc && this.map && this.geoJsonCache[layer] && this.map.getSource(`${layer}-labels-source`)) {
+                const filtered = {
+                    type: 'FeatureCollection',
+                    features: (this.geoJsonCache[layer].features || []).filter(
+                        f => (f.properties?.artcc || '').toLowerCase() === artcc
+                    ),
+                };
+                const labelFeatures = this.createLabelFeatures(filtered);
+                this.map.getSource(`${layer}-labels-source`).setData({
+                    type: 'FeatureCollection',
+                    features: labelFeatures,
+                });
+            }
+        });
+
+        // Zoom to the ARTCC boundary if available
+        this._zoomToArtcc(artcc);
+    },
+
+    /**
+     * Zoom map to fit the selected ARTCC boundary
+     */
+    _zoomToArtcc(artccLower) {
+        if (!this.map || !artccLower) return;
+
+        // Try to find the ARTCC boundary from the ARTCC GeoJSON source
+        const artccData = this.geoJsonCache.artcc;
+        if (!artccData?.features) return;
+
+        const feature = artccData.features.find(
+            f => (f.properties?.id || f.properties?.ID || '').toLowerCase() === artccLower
+        );
+        if (!feature?.geometry?.coordinates) return;
+
+        // Calculate bounding box from the ARTCC polygon
+        let minLng = 180, maxLng = -180, minLat = 90, maxLat = -90;
+        const coords = feature.geometry.type === 'MultiPolygon'
+            ? feature.geometry.coordinates.flat(1)
+            : feature.geometry.coordinates;
+        (coords[0] || []).forEach(([lng, lat]) => {
+            if (lng < minLng) minLng = lng;
+            if (lng > maxLng) maxLng = lng;
+            if (lat < minLat) minLat = lat;
+            if (lat > maxLat) maxLat = lat;
+        });
+
+        if (minLng < maxLng && minLat < maxLat) {
+            this.map.fitBounds([[minLng, minLat], [maxLng, maxLat]], {
+                padding: { top: 40, bottom: 40, left: 440, right: 40 },
+                maxZoom: 9,
+            });
+        }
+    },
+
+    /**
+     * Remove ARTCC filters from sector layers (restore full global view)
+     */
+    _clearSectorLayerFilters() {
+        if (!this.map) return;
+        ['high', 'low', 'superhigh'].forEach(layer => {
+            if (this.map.getLayer(`${layer}-fill`)) this.map.setFilter(`${layer}-fill`, null);
+            if (this.map.getLayer(`${layer}-lines`)) this.map.setFilter(`${layer}-lines`, null);
+
+            // Restore full label data
+            if (this.geoJsonCache[layer] && this.map.getSource(`${layer}-labels-source`)) {
+                const labelFeatures = this.createLabelFeatures(this.geoJsonCache[layer]);
+                this.map.getSource(`${layer}-labels-source`).setData({
+                    type: 'FeatureCollection',
+                    features: labelFeatures,
+                });
             }
         });
     },

--- a/splits.php
+++ b/splits.php
@@ -348,6 +348,26 @@ body.side-panel-active .modal-backdrop {
     }
 }
 
+/* Force single-column layout inside the narrow side panel */
+#config-modal.side-panel-mode .config-step .row > [class*="col-md-"] {
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
+/* Reduce heights to fit both sections vertically in the panel */
+#config-modal.side-panel-mode #config-splits-list {
+    max-height: 200px !important;
+}
+
+#config-modal.side-panel-mode .sector-grid {
+    max-height: 180px;
+    overflow-y: auto;
+}
+
+#config-modal.side-panel-mode .modal-body {
+    overflow-y: auto;
+}
+
 .form-row {
     display: flex;
     gap: 10px;


### PR DESCRIPTION
## Summary
- **API 500 fix**: Removed reference to non-existent `[source]` column in `configs.php` INSERT (migration 012 never deployed), and added `ISNULL()` fallbacks for NOT NULL datetime columns
- **PUT handler fix**: Skip datetime updates when value is empty/null instead of writing NULL to NOT NULL columns (configs.php + scheduled.php)
- **Undefined var fix**: Replaced `$conn_adl_error` (never defined) with `adl_sql_error_message()` across active/configs/scheduled endpoints
- **Map overload fix**: Step 2 side panel now filters sector layers to the selected ARTCC only, rebuilds label sources, and auto-zooms to the ARTCC boundary
- **Squished modal fix**: CSS forces single-column layout inside the 420px side panel so positions and sector grid stack vertically

## Test plan
- [x] POST to configs.php returns 201 with valid payload
- [x] POST with scheduled times works correctly
- [x] PUT update on configs works
- [x] GET list and single config returns 200
- [x] DELETE configs works
- [x] All 10 splits GET endpoints return HTTP 200
- [x] Presets CRUD lifecycle (POST/GET/PUT/DELETE) verified
- [x] Areas POST/DELETE verified
- [x] Scheduled PUT verified
- [ ] Visual verification: step 2 side panel shows only selected ARTCC sectors
- [ ] Visual verification: side panel layout stacks vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)