### PR TITLE
fix(routes): runway-aware DP/STAR expansion

### DIFF
--- a/assets/js/procs_enhanced.js
+++ b/assets/js/procs_enhanced.js
@@ -121,6 +121,23 @@
         return airports;
     }
 
+    // Check if an origGroup string contains a specific runway for a given airport.
+    // origGroup format: "DFW/17C|17R|18L|18R KORD/09R" (FAA or ICAO codes)
+    function origGroupMatchesRunway(origGroup, airport, runway) {
+        if (!origGroup || !airport || !runway) {return false;}
+        const groups = origGroup.split(/\s+/);
+        for (const grp of groups) {
+            const slashIdx = grp.indexOf('/');
+            if (slashIdx < 0) {continue;}
+            const apt = grp.substring(0, slashIdx);
+            const rwys = grp.substring(slashIdx + 1).split('|');
+            if (normalizeAirport(apt) === airport && rwys.indexOf(runway) !== -1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // DP LOADING - loads dp_full_routes.csv
     // ═══════════════════════════════════════════════════════════════════════════
@@ -880,7 +897,7 @@
     /**
      * Get the best matching DP route for a given transition code and origin.
      */
-    window.getDpRoutePoints = function(transCode, originAirport) {
+    window.getDpRoutePoints = function(transCode, originAirport, depRunway) {
         if (!transCode) {return null;}
         const upper = transCode.toUpperCase();
         const records = window.dpFullRoutesByTransition[upper];
@@ -893,7 +910,7 @@
                 const pattern = rootName + '#.' + parts[1];
                 const patternMatch = window.dpPatternIndex[pattern];
                 if (patternMatch) {
-                    return window.getDpRoutePoints(patternMatch.code, originAirport);
+                    return window.getDpRoutePoints(patternMatch.code, originAirport, depRunway);
                 }
             }
             return null;
@@ -909,6 +926,15 @@
             }
         }
 
+        // Filter by departure runway if specified (e.g. depRunway='17C')
+        if (depRunway && originAirport) {
+            const originUpper = normalizeAirport(originAirport.toUpperCase());
+            const rwyFiltered = filtered.filter(r => origGroupMatchesRunway(r.origGroup, originUpper, depRunway));
+            if (rwyFiltered.length > 0) {
+                filtered = rwyFiltered;
+            }
+        }
+
         // Sort by effDate descending and take most recent
         filtered.sort((a, b) => (b.effDate || 0) - (a.effDate || 0));
         const best = filtered[0];
@@ -919,7 +945,7 @@
     /**
      * Get the best matching STAR route for a given transition code and destination.
      */
-    window.getStarRoutePoints = function(transCode, destAirport) {
+    window.getStarRoutePoints = function(transCode, destAirport, arrRunway) {
         if (!transCode) {return null;}
         const upper = transCode.toUpperCase();
         const records = window.starFullRoutesByTransition[upper];
@@ -932,7 +958,7 @@
                 const pattern = parts[0] + '.' + rootName + '#';
                 const patternMatch = window.starPatternIndex[pattern];
                 if (patternMatch) {
-                    return window.getStarRoutePoints(patternMatch.code, destAirport);
+                    return window.getStarRoutePoints(patternMatch.code, destAirport, arrRunway);
                 }
             }
             return null;
@@ -945,6 +971,15 @@
             const destFiltered = records.filter(r => r.destinations && r.destinations.indexOf(destUpper) !== -1);
             if (destFiltered.length > 0) {
                 filtered = destFiltered;
+            }
+        }
+
+        // Filter by arrival runway if specified
+        if (arrRunway && destAirport) {
+            const destUpper = normalizeAirport(destAirport.toUpperCase());
+            const rwyFiltered = filtered.filter(r => origGroupMatchesRunway(r.destGroup, destUpper, arrRunway));
+            if (rwyFiltered.length > 0) {
+                filtered = rwyFiltered;
             }
         }
 
@@ -964,7 +999,7 @@
      * @param {Object} procInfo - Info from preprocessRouteProcedures
      * @returns {Object} { tokens: [...], solidMask: [...], fanRoutes: [...] }
      */
-    window.expandRouteProcedures = function(tokens, solidMask, procInfo) {
+    window.expandRouteProcedures = function(tokens, solidMask, procInfo, depRunway, arrRunway) {
         if (!tokens || !tokens.length) {
             return { tokens: [], solidMask: [], fanRoutes: [] };
         }
@@ -1004,8 +1039,8 @@
             const upper = tok.toUpperCase();
             const solid = inSolid[i];
 
-            // Try to expand as DP transition
-            const dpRoute = window.getDpRoutePoints(upper, originAirport);
+            // Try to expand as DP transition (with runway context)
+            const dpRoute = window.getDpRoutePoints(upper, originAirport, depRunway);
             if (dpRoute && dpRoute.length) {
                 for (const pt of dpRoute) {
                     outTokens.push(pt);
@@ -1014,8 +1049,8 @@
                 continue;
             }
 
-            // Try to expand as STAR transition
-            const starRoute = window.getStarRoutePoints(upper, destAirport);
+            // Try to expand as STAR transition (with runway context)
+            const starRoute = window.getStarRoutePoints(upper, destAirport, arrRunway);
             if (starRoute && starRoute.length) {
                 for (const pt of starRoute) {
                     outTokens.push(pt);

--- a/assets/js/route-maplibre.js
+++ b/assets/js/route-maplibre.js
@@ -2964,6 +2964,29 @@ $(document).ready(function() {
 
             if (origTokensClean.length === 0) {return;}
 
+            // Strip AIRPORT/RUNWAY tokens: extract runway context for procedure filtering,
+            // replace token with just the airport code so it resolves in point lookups.
+            // E.g. KDFW/17C → KDFW (depRunway='17C'), KJFK/31L → KJFK (arrRunway='31L')
+            let depRunway = null, arrRunway = null;
+            for (let ti = 0; ti < origTokensClean.length; ti++) {
+                const tok = origTokensClean[ti];
+                const slashIdx = tok.indexOf('/');
+                if (slashIdx <= 0) {continue;}
+                // Skip coordinate tokens like 55/40 or 5540/04020
+                if (/^\d{2,5}\/\d{2,5}$/.test(tok)) {continue;}
+                const apt = tok.substring(0, slashIdx);
+                const rwy = tok.substring(slashIdx + 1);
+                // Validate: airport=3-4 alpha, runway=1-2 digits + optional L/C/R
+                if (/^[A-Z]{3,4}$/.test(apt) && /^\d{1,2}[LCR]?$/.test(rwy)) {
+                    origTokensClean[ti] = apt;
+                    if (depRunway === null) {
+                        depRunway = rwy;
+                    } else {
+                        arrRunway = rwy;
+                    }
+                }
+            }
+
             let tokens = origTokensClean.slice();
             let currentSolidMask = solidMask.slice();
 
@@ -3005,13 +3028,13 @@ $(document).ready(function() {
 
             let routeProcInfo = null;
             if (typeof preprocessRouteProcedures === 'function') {
-                routeProcInfo = preprocessRouteProcedures(tokens);
+                routeProcInfo = preprocessRouteProcedures(tokens, depRunway, arrRunway);
                 if (routeProcInfo && routeProcInfo.tokens) {tokens = routeProcInfo.tokens;}
             }
             routeStringByRouteId[thisRouteId].procInfo = routeProcInfo || null;
             routeStringByRouteId[thisRouteId].originalTokens = tokens.slice();
             if (typeof expandRouteProcedures === 'function') {
-                const expanded = expandRouteProcedures(tokens, currentSolidMask);
+                const expanded = expandRouteProcedures(tokens, currentSolidMask, null, depRunway, arrRunway);
                 if (expanded && expanded.tokens) {
                     tokens = expanded.tokens;
                     currentSolidMask = expanded.solidMask || currentSolidMask;
@@ -7611,6 +7634,19 @@ $(document).ready(function() {
             const tokens = line.split(/\s+/).filter(Boolean);
             if (!tokens.length) {return;}
 
+            // Strip AIRPORT/RUNWAY suffixes so airport detection works
+            for (let ti = 0; ti < tokens.length; ti++) {
+                const tok = tokens[ti].replace(/[<>]/g, '').toUpperCase();
+                const slashIdx = tok.indexOf('/');
+                if (slashIdx > 0 && !/^\d{2,5}\/\d{2,5}$/.test(tok)) {
+                    const apt = tok.substring(0, slashIdx);
+                    const rwy = tok.substring(slashIdx + 1);
+                    if (/^[A-Z]{3,4}$/.test(apt) && /^\d{1,2}[LCR]?$/.test(rwy)) {
+                        tokens[ti] = apt;
+                    }
+                }
+            }
+
             // Find all facilities in the route (excluding airways which start with J/Q/V/T + digits)
             const facilityIdxs = [];
             const airportIdxs = [];
@@ -9108,8 +9144,19 @@ $(document).ready(function() {
             cleanRoute = natExpanded;
         }
 
-        // Parse tokens
+        // Parse tokens and strip AIRPORT/RUNWAY suffixes
         const tokens = cleanRoute.split(/\s+/).filter(t => t);
+        for (let ti = 0; ti < tokens.length; ti++) {
+            const tok = tokens[ti];
+            const slashIdx = tok.indexOf('/');
+            if (slashIdx > 0 && !/^\d{2,5}\/\d{2,5}$/.test(tok)) {
+                const apt = tok.substring(0, slashIdx);
+                const rwy = tok.substring(slashIdx + 1);
+                if (/^[A-Z]{3,4}$/.test(apt) && /^\d{1,2}[LCR]?$/.test(rwy)) {
+                    tokens[ti] = apt;
+                }
+            }
+        }
 
         // Detect origins and destinations
         const origins = [];


### PR DESCRIPTION
## Summary
- Fixes route strings with runway notation (e.g. `KDFW/17C KATZZ2.BRHMA`) not expanding or mapping properly in route.php
- Strips `/RUNWAY` suffix from airport tokens so `getPointByName()` resolves the airport correctly
- Passes runway context through the full DP/STAR expansion pipeline to select runway-specific procedure routes
- Filters DP records by `origGroup` runway match and STAR records by `destGroup` runway match, with graceful fallback

## Test plan
- [ ] Plot `KDFW KATZZ2.BRHMA` — should show default route (ROOOO RUFFS KATZZ BRHMA)
- [ ] Plot `KDFW/17C KATZZ2.BRHMA` — should show 17C route (LARRN GIGEM TANNO ROOOO RUFFS KATZZ BRHMA)
- [ ] Plot `KDFW/35C KATZZ2.BRHMA` — should show 35C route (GVINE KMART MARSN ROOOO RUFFS KATZZ BRHMA)
- [ ] Plot `KDFW/31L KATZZ2.BRHMA` — should show 31L route (ROOOO RUFFS KATZZ BRHMA)
- [ ] Plot `KDFW/35R KATZZ2.BRHMA` — 35R not in any group, should fallback to default
- [ ] Verify NAT coordinates like `55/40` are NOT stripped
- [ ] Verify playbook routes and CDR expansion still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)