### PR TITLE
fix(timeline): allow facility list changes in consolidated edit

### DIFF
--- a/assets/js/initiative_timeline.js
+++ b/assets/js/initiative_timeline.js
@@ -1614,45 +1614,113 @@ class InitiativeTimeline {
 
     async saveConsolidatedItems(data) {
         const ids = this._consolidatedIds;
-        const facilities = this._consolidatedFacilities;
+        const oldFacilities = this._consolidatedFacilities;
         if (!ids || !ids.length) return;
 
+        // Parse the new facility list from user input (split on / , -)
+        const newFacilities = data.facility
+            .split(/[\/,\-]+/)
+            .map(f => f.trim())
+            .filter(f => f.length >= 2);
+
+        // Check if user actually changed the facility list
+        const oldSet = new Set(oldFacilities.map(f => f.toUpperCase()));
+        const newSet = new Set(newFacilities.map(f => f.toUpperCase()));
+        const facilitiesChanged = oldSet.size !== newSet.size ||
+            [...oldSet].some(f => !newSet.has(f));
+
         let successCount = 0;
+        let totalOps = 0;
         let lastError = null;
 
-        for (let i = 0; i < ids.length; i++) {
-            const itemData = { ...data, id: ids[i] };
-            // Restore each item's original facility
-            if (facilities[i]) {
-                itemData.facility = facilities[i];
-            }
-            try {
-                const resp = await fetch(this.apiEndpoint, {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(itemData),
-                });
-                const result = await resp.json();
-                if (result.success) {
-                    successCount++;
-                } else {
-                    lastError = result.error;
+        if (!facilitiesChanged) {
+            // Facilities unchanged — update each record with its original facility (existing behavior)
+            totalOps = ids.length;
+            for (let i = 0; i < ids.length; i++) {
+                const itemData = { ...data, id: ids[i] };
+                if (oldFacilities[i]) {
+                    itemData.facility = oldFacilities[i];
                 }
-            } catch (e) {
-                lastError = e.message;
+                try {
+                    const resp = await fetch(this.apiEndpoint, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(itemData),
+                    });
+                    const result = await resp.json();
+                    if (result.success) successCount++;
+                    else lastError = result.error;
+                } catch (e) { lastError = e.message; }
+            }
+        } else {
+            // Facilities changed — reconcile: delete removed, update kept, create new
+            // Build map: uppercase facility → record ID
+            const oldMap = {};
+            for (let i = 0; i < oldFacilities.length; i++) {
+                oldMap[oldFacilities[i].toUpperCase()] = ids[i];
+            }
+
+            const toDelete = oldFacilities.filter(f => !newSet.has(f.toUpperCase()));
+            const toKeep = newFacilities.filter(f => oldSet.has(f.toUpperCase()));
+            const toCreate = newFacilities.filter(f => !oldSet.has(f.toUpperCase()));
+            totalOps = toDelete.length + toKeep.length + toCreate.length;
+
+            // Delete removed facilities
+            for (const fac of toDelete) {
+                const rid = oldMap[fac.toUpperCase()];
+                if (!rid) continue;
+                try {
+                    const resp = await fetch(`${this.apiEndpoint}?id=${rid}`, { method: 'DELETE' });
+                    const result = await resp.json();
+                    if (result.success) successCount++;
+                    else lastError = result.error;
+                } catch (e) { lastError = e.message; }
+            }
+
+            // Update kept facilities
+            for (const fac of toKeep) {
+                const rid = oldMap[fac.toUpperCase()];
+                if (!rid) continue;
+                const itemData = { ...data, id: rid, facility: fac };
+                try {
+                    const resp = await fetch(this.apiEndpoint, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(itemData),
+                    });
+                    const result = await resp.json();
+                    if (result.success) successCount++;
+                    else lastError = result.error;
+                } catch (e) { lastError = e.message; }
+            }
+
+            // Create new facilities (POST with single facility each)
+            for (const fac of toCreate) {
+                const itemData = { ...data, facility: fac };
+                delete itemData.id;
+                try {
+                    const resp = await fetch(this.apiEndpoint, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(itemData),
+                    });
+                    const result = await resp.json();
+                    if (result.success) successCount++;
+                    else lastError = result.error;
+                } catch (e) { lastError = e.message; }
             }
         }
 
         this._consolidatedIds = null;
         this._consolidatedFacilities = null;
 
-        if (successCount === ids.length) {
+        if (successCount === totalOps) {
             $(`#${this.modalId}`).modal('hide');
             this.alert('success', PERTII18n.t('initiative.elementUpdated') + ` (${successCount})`);
             this.loadData();
         } else if (successCount > 0) {
             $(`#${this.modalId}`).modal('hide');
-            this.alert('warning', PERTII18n.t('initiative.partialUpdate', { success: successCount, total: ids.length }) + (lastError ? ': ' + lastError : ''));
+            this.alert('warning', PERTII18n.t('initiative.partialUpdate', { success: successCount, total: totalOps }) + (lastError ? ': ' + lastError : ''));
             this.loadData();
         } else {
             this.alert('error', lastError || PERTII18n.t('initiative.error.saveFailed'));

--- a/docs/operations/HIBERNATION_RUNBOOK.md
+++ b/docs/operations/HIBERNATION_RUNBOOK.md
@@ -4,8 +4,8 @@
 
 Hibernation mode is an open-ended operational pause that reduces PERTI to core data collection plus VATSWIM. Most downstream flight processing and several UI pages are suspended, but **SWIM API, SWIM pages, and SWIM daemons remain fully operational**. Azure resources are downscaled to match the reduced workload.
 
-**Status**: Active (entered 2026-03-30)
-**History**: Active March 2026 - March 7, 2026; Re-entered March 9, 2026; Exited March 12, 2026; Re-entered March 13, 2026 with SWIM exemption; Exited March 20, 2026; Re-entered March 22, 2026 with PostGIS at B2s + review/TMR/TMI Compliance exemption; Exited March 29, 2026; Re-entered March 29, 2026; Exited March 30, 2026; Re-entered March 30, 2026
+**Status**: Inactive (exited 2026-04-19)
+**History**: Active March 2026 - March 7, 2026; Re-entered March 9, 2026; Exited March 12, 2026; Re-entered March 13, 2026 with SWIM exemption; Exited March 20, 2026; Re-entered March 22, 2026 with PostGIS at B2s + review/TMR/TMI Compliance exemption; Exited March 29, 2026; Re-entered March 29, 2026; Exited March 30, 2026; Re-entered March 30, 2026; Exited April 19, 2026
 
 ---
 
@@ -86,7 +86,7 @@ This controls:
 
 ### Azure App Setting
 
-**Setting**: `HIBERNATION_MODE=true`
+**Setting**: `HIBERNATION_MODE=1` (use `1` to enable, `0` to disable; do NOT use `true`/`false` strings)
 
 This controls:
 - Daemon startup behavior in `scripts/startup.sh`
@@ -185,7 +185,9 @@ define("HIBERNATION_MODE", env('HIBERNATION_MODE', false));
 ### 3. Remove Azure App Setting
 
 In Azure Portal: App Service → Configuration → Application settings
-Remove or set `HIBERNATION_MODE` to `false`.
+Remove or set `HIBERNATION_MODE` to `0`.
+
+> **Warning**: Do NOT set to `false` — the string `"false"` is truthy in PHP (any non-empty string except `"0"` is truthy). Use `0` or remove the setting entirely.
 
 ### 4. Restart App Service
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `saveConsolidatedItems()` silently overwrote the user's facility edits with each record's original facility, making it impossible to add/remove facilities from a consolidated timeline group (e.g. changing `BRZ/CAN/CAR/EUD/MENA/MEX/NAT/RUS/UK/USA` to `CAN/EU/USA`)
- **Reconciliation logic**: When facilities change, the code now deletes removed facilities, updates kept ones, and creates new ones via POST
- **Hibernation runbook**: Updated status to inactive and added PHP truthy string warning for `HIBERNATION_MODE` setting

## Test plan
- [ ] Open a plan with consolidated enroute/terminal timeline items
- [ ] Edit a consolidated group and change the facility list (remove some, add new ones)
- [ ] Verify removed facilities are deleted, kept facilities are updated, new facilities are created
- [ ] Edit a consolidated group without changing facilities — verify existing behavior preserved
- [ ] Verify single (non-consolidated) item edits still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)