### PR TITLE
fix: prevent FPM worker saturation from slow SQL queries

### DIFF
--- a/api/adl/current.php
+++ b/api/adl/current.php
@@ -59,9 +59,11 @@ if (!function_exists('sqlsrv_connect')) {
 }
 
 $connectionInfo = [
-    "Database" => ADL_SQL_DATABASE,
-    "UID"      => ADL_SQL_USERNAME,
-    "PWD"      => ADL_SQL_PASSWORD
+    "Database"         => ADL_SQL_DATABASE,
+    "UID"              => ADL_SQL_USERNAME,
+    "PWD"              => ADL_SQL_PASSWORD,
+    "LoginTimeout"     => 10,
+    "ConnectionPooling" => true
 ];
 
 $conn_adl = sqlsrv_connect(ADL_SQL_HOST, $connectionInfo);
@@ -124,13 +126,12 @@ $params = $query['params'];
 // 7) Execute query
 // ---------------------------------------------------------------------------
 
-$stmt = sqlsrv_query($conn_adl, $sql, $params);
+$stmt = sqlsrv_query($conn_adl, $sql, $params, ["QueryTimeout" => 30]);
 if ($stmt === false) {
-    http_response_code(500);
+    http_response_code(504);
     echo json_encode([
         "error" => "Database error when querying ADL (current).",
-        "sql_error" => adl_sql_error_message(),
-        "sql" => $sql
+        "sql_error" => adl_sql_error_message()
     ]);
     exit;
 }

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -444,8 +444,12 @@ if [ -f "$FPM_CONF" ]; then
     # Enable status page for monitoring (access via /fpm-status)
     sed -i 's/^;pm.status_path = .*/pm.status_path = \/fpm-status/' "$FPM_CONF"
     grep -q '^pm.status_path' "$FPM_CONF" || echo 'pm.status_path = /fpm-status' >> "$FPM_CONF"
+    # Kill workers that run longer than 90 seconds — prevents runaway DB queries from
+    # consuming all FPM workers and causing site-wide 504s (incident 2026-04-25)
+    sed -i 's/^;*request_terminate_timeout = .*/request_terminate_timeout = 90/' "$FPM_CONF"
+    grep -q '^request_terminate_timeout' "$FPM_CONF" || echo 'request_terminate_timeout = 90' >> "$FPM_CONF"
     echo "  PHP-FPM configured: max_children=$FPM_MAX_CHILDREN, start=$FPM_START, min_spare=$FPM_MIN_SPARE, max_spare=$FPM_MAX_SPARE"
-    echo "  Status page enabled at /fpm-status"
+    echo "  request_terminate_timeout=90s, status page enabled at /fpm-status"
 else
     echo "  WARNING: FPM config not found at $FPM_CONF"
 fi


### PR DESCRIPTION
## Summary

- Adds `request_terminate_timeout=90s` to PHP-FPM config in `startup.sh` — kills any worker stuck beyond 90 seconds, preventing runaway DB queries from consuming all FPM workers
- Adds `QueryTimeout=30s` to the `/api/adl/current.php` SQL query — aborts after 30s and returns 504 instead of blocking the worker indefinitely
- Adds `LoginTimeout=10s` and `ConnectionPooling` to the `current.php` connection config
- Removes raw SQL from error responses

## Context

On 2026-04-25, all 40 PHP-FPM workers became stuck on `/api/adl/current.php` queries that hung for 3-6+ minutes on Azure SQL (5-table JOIN across normalized ADL tables). This caused site-wide 504 Gateway Timeouts on all pages, including the zero-DB healthcheck (11s response time). Root cause was Azure SQL contention; multiple browser tabs with auto-refresh on `nod.js`, `route-maplibre.js`, etc. piled up concurrent requests that never completed.

## Test plan

- [ ] Verify site loads normally after deploy (healthcheck <1s, tmi-publish <3s)
- [ ] Confirm FPM status page shows `request_terminate_timeout = 90` in startup log
- [ ] Verify `/api/adl/current.php` returns data within ~2-5s under normal conditions
- [ ] Confirm slow queries return 504 (not hang) if Azure SQL is under pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)