### PR TITLE
fix: prevent FPM worker saturation with APCu cache

### DIFF
--- a/api/adl/current.php
+++ b/api/adl/current.php
@@ -59,9 +59,11 @@ if (!function_exists('sqlsrv_connect')) {
 }
 
 $connectionInfo = [
-    "Database" => ADL_SQL_DATABASE,
-    "UID"      => ADL_SQL_USERNAME,
-    "PWD"      => ADL_SQL_PASSWORD
+    "Database"         => ADL_SQL_DATABASE,
+    "UID"              => ADL_SQL_USERNAME,
+    "PWD"              => ADL_SQL_PASSWORD,
+    "LoginTimeout"     => 10,
+    "ConnectionPooling" => true
 ];
 
 $conn_adl = sqlsrv_connect(ADL_SQL_HOST, $connectionInfo);
@@ -124,13 +126,12 @@ $params = $query['params'];
 // 7) Execute query
 // ---------------------------------------------------------------------------
 
-$stmt = sqlsrv_query($conn_adl, $sql, $params);
+$stmt = sqlsrv_query($conn_adl, $sql, $params, ["QueryTimeout" => 30]);
 if ($stmt === false) {
-    http_response_code(500);
+    http_response_code(504);
     echo json_encode([
         "error" => "Database error when querying ADL (current).",
-        "sql_error" => adl_sql_error_message(),
-        "sql" => $sql
+        "sql_error" => adl_sql_error_message()
     ]);
     exit;
 }

--- a/api/adl/current.php
+++ b/api/adl/current.php
@@ -11,11 +11,61 @@ if (session_status() == PHP_SESSION_NONE) {
 header('Content-Type: application/json; charset=utf-8');
 
 // ---------------------------------------------------------------------------
-// 1) Ensure ADL DB connection constants exist
+// 1) Load config, input helpers, cache
 // ---------------------------------------------------------------------------
 
 require_once("../../load/config.php"); // should define ADL_SQL_HOST, ADL_SQL_DATABASE, ADL_SQL_USERNAME, ADL_SQL_PASSWORD
 require_once("../../load/input.php"); // Safe input functions for PHP 8.2+
+require_once("../../load/cache.php");
+
+// ---------------------------------------------------------------------------
+// 2) Input parameters (parsed early so we can build cache key before DB)
+// ---------------------------------------------------------------------------
+
+$callsign = '';
+if (isset($_GET['cs'])) {
+    $callsign = get_upper('cs');
+} elseif (isset($_GET['callsign'])) {
+    $callsign = get_upper('callsign');
+}
+
+$dep = isset($_GET['dep']) ? get_upper('dep') : '';
+$arr = isset($_GET['arr']) ? get_upper('arr') : '';
+
+// active flag: default is only active flights
+$activeParam = isset($_GET['active']) ? get_lower('active') : '1';
+$activeOnly = ($activeParam !== 'all' && $activeParam !== '0' && $activeParam !== 'false' && $activeParam !== 'no');
+
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 10000;
+if ($limit <= 0) {
+    $limit = 10000;
+} elseif ($limit > 15000) {
+    $limit = 15000;
+}
+
+// ---------------------------------------------------------------------------
+// 3) APCu cache check — skip DB entirely on HIT
+// ---------------------------------------------------------------------------
+
+$cacheKey = cache_key('adl_current', [
+    'active' => $activeOnly ? '1' : '0',
+    'cs' => $callsign,
+    'dep' => $dep,
+    'arr' => $arr,
+    'limit' => $limit
+]);
+
+$cached = apcu_cache_get($cacheKey);
+if ($cached !== null) {
+    header('X-Cache: HIT');
+    header('Cache-Control: public, max-age=10');
+    echo $cached;  // Pre-encoded JSON string
+    exit;
+}
+
+// ---------------------------------------------------------------------------
+// 4) Ensure ADL DB connection constants exist
+// ---------------------------------------------------------------------------
 
 if (!defined("ADL_SQL_HOST") || !defined("ADL_SQL_DATABASE") ||
     !defined("ADL_SQL_USERNAME") || !defined("ADL_SQL_PASSWORD")) {
@@ -47,7 +97,7 @@ function adl_sql_error_message()
 }
 
 // ---------------------------------------------------------------------------
-// 2) Connect to Azure SQL ADL database
+// 5) Connect to Azure SQL ADL database
 // ---------------------------------------------------------------------------
 
 if (!function_exists('sqlsrv_connect')) {
@@ -77,39 +127,14 @@ if ($conn_adl === false) {
 }
 
 // ---------------------------------------------------------------------------
-// 3) Use ADL Query Helper for normalized table support
+// 6) Use ADL Query Helper for normalized table support
 // ---------------------------------------------------------------------------
 
 require_once(__DIR__ . '/AdlQueryHelper.php');
 $helper = new AdlQueryHelper();
 
 // ---------------------------------------------------------------------------
-// 4) Input parameters
-// ---------------------------------------------------------------------------
-
-$callsign = '';
-if (isset($_GET['cs'])) {
-    $callsign = get_upper('cs');
-} elseif (isset($_GET['callsign'])) {
-    $callsign = get_upper('callsign');
-}
-
-$dep = isset($_GET['dep']) ? get_upper('dep') : '';
-$arr = isset($_GET['arr']) ? get_upper('arr') : '';
-
-// active flag: default is only active flights
-$activeParam = isset($_GET['active']) ? get_lower('active') : '1';
-$activeOnly = ($activeParam !== 'all' && $activeParam !== '0' && $activeParam !== 'false' && $activeParam !== 'no');
-
-$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 10000;
-if ($limit <= 0) {
-    $limit = 10000;
-} elseif ($limit > 15000) {
-    $limit = 15000;
-}
-
-// ---------------------------------------------------------------------------
-// 5) Build query using helper (supports view or normalized tables)
+// 7) Build and execute query
 // ---------------------------------------------------------------------------
 
 $query = $helper->buildCurrentFlightsQuery([
@@ -121,10 +146,6 @@ $query = $helper->buildCurrentFlightsQuery([
 ]);
 $sql = $query['sql'];
 $params = $query['params'];
-
-// ---------------------------------------------------------------------------
-// 7) Execute query
-// ---------------------------------------------------------------------------
 
 $stmt = sqlsrv_query($conn_adl, $sql, $params, ["QueryTimeout" => 30]);
 if ($stmt === false) {
@@ -171,9 +192,17 @@ if (!empty($rows) && isset($rows[0]['snapshot_utc'])) {
     }
 }
 
-echo json_encode([
+// ---------------------------------------------------------------------------
+// 9) Cache the JSON response and return
+// ---------------------------------------------------------------------------
+
+$json = json_encode([
     "snapshot_utc" => $snapshotUtc,
     "flights"      => $rows
 ]);
+apcu_cache_set($cacheKey, $json, 15);  // 15s TTL = one daemon cycle
+header('X-Cache: MISS');
+header('Cache-Control: public, max-age=10');
+echo $json;
 
 ?>

--- a/load/cache.php
+++ b/load/cache.php
@@ -66,3 +66,15 @@ function demand_cache_key($endpoint, $params = []) {
     ksort($params); // Ensure consistent key ordering
     return 'demand:' . $endpoint . ':' . md5(json_encode($params));
 }
+
+/**
+ * Build a generic cache key (for non-demand endpoints)
+ *
+ * @param string $namespace Namespace prefix (e.g., 'adl_current')
+ * @param array $params Key-value pairs to include in the cache key
+ * @return string Cache key
+ */
+function cache_key($namespace, $params = []) {
+    ksort($params);
+    return $namespace . ':' . md5(json_encode($params));
+}

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -409,6 +409,29 @@ opcache.fast_shutdown=1
 OPCACHE_EOF
 echo "  OPcache configured (128MB, revalidate every 60s)"
 
+# Install APCu for server-side response caching
+# Used by demand endpoints, ADL current flights, and SWIM API
+if php -m 2>/dev/null | grep -q apcu; then
+    echo "  APCu already installed"
+else
+    echo "Installing APCu..."
+    pecl install apcu >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "  APCu installed successfully"
+    else
+        echo "  WARNING: APCu installation failed — caching will be disabled"
+    fi
+fi
+# Configure APCu (idempotent — writes config even if install was from a previous boot)
+APCU_INI="/usr/local/etc/php/conf.d/apcu.ini"
+cat > "$APCU_INI" << 'APCU_EOF'
+extension=apcu
+apc.enabled=1
+apc.shm_size=64M
+apc.enable_cli=0
+APCU_EOF
+echo "  APCu configured (64MB SHM)"
+
 # Configure PHP-FPM for higher concurrency
 # Default is only 5 workers which causes request queueing under load
 #

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -444,8 +444,12 @@ if [ -f "$FPM_CONF" ]; then
     # Enable status page for monitoring (access via /fpm-status)
     sed -i 's/^;pm.status_path = .*/pm.status_path = \/fpm-status/' "$FPM_CONF"
     grep -q '^pm.status_path' "$FPM_CONF" || echo 'pm.status_path = /fpm-status' >> "$FPM_CONF"
+    # Kill workers that run longer than 90 seconds — prevents runaway DB queries from
+    # consuming all FPM workers and causing site-wide 504s (incident 2026-04-25)
+    sed -i 's/^;*request_terminate_timeout = .*/request_terminate_timeout = 90/' "$FPM_CONF"
+    grep -q '^request_terminate_timeout' "$FPM_CONF" || echo 'request_terminate_timeout = 90' >> "$FPM_CONF"
     echo "  PHP-FPM configured: max_children=$FPM_MAX_CHILDREN, start=$FPM_START, min_spare=$FPM_MIN_SPARE, max_spare=$FPM_MAX_SPARE"
-    echo "  Status page enabled at /fpm-status"
+    echo "  request_terminate_timeout=90s, status page enabled at /fpm-status"
 else
     echo "  WARNING: FPM config not found at $FPM_CONF"
 fi


### PR DESCRIPTION
## Summary

- Installs APCu extension in `startup.sh` (was missing from Azure container) with 64MB SHM, enabling server-side response caching for **14 endpoints** that already had the code but were silently degrading to no-cache
- Adds APCu cache to `/api/adl/current.php` with 15s TTL — on cache HIT, skips `sqlsrv_connect()` entirely (~500ms saved per request), so only one SQL query runs per daemon cycle regardless of user count
- Adds `request_terminate_timeout=90s` to PHP-FPM to kill workers stuck on slow DB queries, preventing total site lockout

## Context

On 2026-04-25, all 40 PHP-FPM workers got stuck because multiple browser tabs (NOD, route map, GDT) each independently query `current.php?limit=10000&active=1` every 15s. With N users x M tabs, that's dozens of concurrent identical 5-table JOINs hitting Azure SQL. Since the ADL daemon only refreshes every 15s, all queries return the same data — they're redundant.

## Test plan

- [ ] After deploy, confirm APCu is loaded: `php -m | grep apcu`
- [ ] Hit `current.php` twice within 15s — second response should have `X-Cache: HIT` header and return in <50ms
- [ ] Confirm `X-Cache: MISS` after 15s expiry
- [ ] Verify `Cache-Control: public, max-age=10` in response headers
- [ ] Filtered call (`?cs=DAL123`) caches independently from unfiltered
- [ ] Response JSON shape unchanged — no JS breakage
- [ ] Demand endpoints (`/api/demand/summary.php` etc.) should now show `X-Cache: HIT/MISS` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)