### PR TITLE
fix(ctp): set is_active=1 on CTP slot programs

### DIFF
--- a/load/services/CTPSlotEngine.php
+++ b/load/services/CTPSlotEngine.php
@@ -133,7 +133,7 @@ class CTPSlotEngine
                      gaming_flags_count, gs_release_followon)
                  OUTPUT INSERTED.program_id
                  VALUES (?, 'FIR', 'CTP', ?,
-                         ?, ?, 'ACTIVE', 1, 0,
+                         ?, ?, 'ACTIVE', 0, 1,
                          ?, 180, 1.00,
                          'ALL', 1, 0,
                          'SYSTEM', SYSUTCDATETIME(), SYSUTCDATETIME(), 0,


### PR DESCRIPTION
## Summary
- CTPSlotEngine created `tmi_programs` with `is_proposed=1, is_active=0`, but the ADL daemon's `executeDeferredTMISync()` filters `WHERE p.is_active = 1`
- This caused all CTP flight control CTD/EDCT values to be invisible to the sync pipeline, so they never appeared in ADL or SWIM
- Swap the flags to `is_proposed=0, is_active=1` so CTP programs are immediately active and their CTDs propagate through the TMI→ADL→SWIM pipeline

## Test plan
- [x] Verified GS programs (is_active=1) have CTD values in adl_flight_times and swim_flights
- [x] Verified CTP programs (is_active=0) had NULL CTD values in both ADL and SWIM
- [x] Updated 42 existing CTP/CTP_SLOT programs in DB to is_active=1
- [ ] Confirm CTD values propagate for new CTP slot programs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)